### PR TITLE
Add GSLIST2ARY_STR macro family

### DIFF
--- a/glib2/ext/glib2/glib2.def
+++ b/glib2/ext/glib2/glib2.def
@@ -100,8 +100,11 @@ EXPORTS
 	rbgutil_glist2ary_string_and_free
 	rbgutil_gslist2ary
 	rbgutil_gslist2ary_boxed
+	rbgutil_gslist2ary_string
 	rbgutil_gslist2ary_and_free
 	rbgutil_gslist2ary_boxed_and_free
+	rbgutil_gslist2ary_string_and_free
+	rbgutil_gslist2ary_string_and_free_list
 	rbgutil_set_properties
 	rbgutil_sym_g2r_func
 	rbgutil_protect

--- a/glib2/ext/glib2/rbgutil.c
+++ b/glib2/ext/glib2/rbgutil.c
@@ -278,6 +278,66 @@ rbgutil_gslist2ary_boxed_and_free(GSList *const list, GType gtype)
 }
 
 VALUE
+rbgutil_gslist2ary_string(const GSList *const list)
+{
+    VALUE ary;
+    const GSList *i;
+
+    ary = rb_ary_new();
+    for (i = list; i != NULL; i = i->next)
+        rb_ary_push(ary, CSTR2RVAL(i->data));
+
+    return ary;
+}
+
+static VALUE
+rbgutil_gslist2ary_string_and_free_body(VALUE data)
+{
+    VALUE ary;
+    GSList *i;
+
+    ary = rb_ary_new();
+    for (i = (GSList *)data; i != NULL; i = i->next)
+        rb_ary_push(ary, CSTR2RVAL(i->data));
+
+    return ary;
+}
+
+static VALUE
+rbgutil_gslist2ary_string_and_free_ensure(VALUE data)
+{
+    GSList *i;
+
+    for (i = (GSList *)data; i != NULL; i = i->next)
+        g_free(i->data);
+    g_slist_free((GSList *)data);
+
+    return Qnil;
+}
+
+VALUE
+rbgutil_gslist2ary_string_and_free(GSList *const list)
+{
+    return rb_ensure(rbgutil_gslist2ary_string_and_free_body, (VALUE)list,
+                     rbgutil_gslist2ary_string_and_free_ensure, (VALUE)list);
+}
+
+static VALUE
+rbgutil_gslist2ary_string_and_free_list_ensure(VALUE data)
+{
+    g_slist_free((GSList *)data);
+
+    return Qnil;
+}
+
+VALUE
+rbgutil_gslist2ary_string_and_free_list(GSList *const list)
+{
+    return rb_ensure(rbgutil_gslist2ary_string_and_free_body, (VALUE)list,
+                     rbgutil_gslist2ary_string_and_free_list_ensure, (VALUE)list);
+}
+
+VALUE
 rbgutil_def_setters(VALUE klass)
 {
     return rb_funcall(mGLib, id_add_one_arg_setter, 1, klass);

--- a/glib2/ext/glib2/rbgutil.h
+++ b/glib2/ext/glib2/rbgutil.h
@@ -95,6 +95,9 @@ extern "C" {
 #define GSLIST2ARYF(list)         (GSLIST2ARY_FREE(list))
 #define GSLIST2ARY2(list, gtype)  (rbgutil_gslist2ary_boxed(list, gtype))
 #define GSLIST2ARY2F(list, gtype) (rbgutil_gslist2ary_boxed_and_free(list, gtype))
+#define GSLIST2ARY_STR(list)      (rbgutil_gslist2ary_string(list))
+#define GSLIST2ARY_STR_FREE(list) (rbgutil_gslist2ary_string_and_free(list))
+#define GSLIST2ARY_STR_FREE_LIST(list) (rbgutil_gslist2ary_string_and_free_list(list))
 
 #define RBG_STRING_SET_UTF8_ENCODING(string) \
     (rbgutil_string_set_utf8_encoding(string))
@@ -111,6 +114,9 @@ extern VALUE rbgutil_gslist2ary(const GSList *list);
 extern VALUE rbgutil_gslist2ary_and_free(GSList *list);
 extern VALUE rbgutil_gslist2ary_boxed(const GSList *list, GType gtype);
 extern VALUE rbgutil_gslist2ary_boxed_and_free(GSList *list, GType gtype);
+extern VALUE rbgutil_gslist2ary_string(const GSList *list);
+extern VALUE rbgutil_gslist2ary_string_and_free(GSList *list);
+extern VALUE rbgutil_gslist2ary_string_and_free_list(GSList *list);
 extern VALUE rbgutil_protect(VALUE (*proc) (VALUE), VALUE data);
 extern VALUE rbgutil_invoke_callback(VALUE (*func)(VALUE), VALUE arg);
 extern void rbgutil_start_callback_dispatch_thread(void);


### PR DESCRIPTION
GSLIST2ARY_STR_FREE_LIST is needed for the following:
gtk_widget_path_iter_list_classes
gtk_widget_path_iter_list_regions
