### PR TITLE
Update gstreamer/lib/gst.rb

### DIFF
--- a/gstreamer/lib/gst.rb
+++ b/gstreamer/lib/gst.rb
@@ -16,8 +16,6 @@ rescue LoadError
   require "gstreamer.so"
 end
 
-Gst.init
-
 module Gst
   class Plugin
     def each_feature(&block)


### PR DESCRIPTION
Gst.init should not be called when loading module as it will by default load the cmd line argument
preventing the script from which it is loaded to use the cmd line args.
Then, the normal way a script should use gst and disable the cmd line args is:

require 'gst'
Gst.init([])
