### PR TITLE
gtk2: fix Gtk::TreeIter memory leak

### DIFF
--- a/gtk2/ext/gtk2/rbgtkliststore.c
+++ b/gtk2/ext/gtk2/rbgtkliststore.c
@@ -73,7 +73,6 @@ rg_set_value(VALUE self, VALUE iter, VALUE column, VALUE value)
 
     rbgobj_rvalue_to_gvalue(value, &gval);
 
-    G_CHILD_ADD(self, iter);
     G_CHILD_ADD(iter, value);
 
     gtk_list_store_set_value(_SELF(self), RVAL2GTKTREEITER(iter), NUM2INT(column), &gval);
@@ -156,8 +155,6 @@ rg_set_values(VALUE self, VALUE iter, VALUE values)
     g_columns = ALLOCA_N(gint, length);
     g_values = ALLOCA_N(GValue, length);
     MEMZERO(g_values, GValue, length);
-
-    G_CHILD_ADD(self, iter);
 
     store = _SELF(self);
     model = GTK_TREE_MODEL(store);
@@ -288,8 +285,6 @@ rg_insert(int argc, VALUE *argv, VALUE self)
 
     result = GTKTREEITER2RVAL(&args.iter);
 
-    G_CHILD_ADD(self, result);
-
     return result;
 }
 
@@ -303,7 +298,6 @@ rg_insert_before(VALUE self, VALUE sibling)
     iter.user_data3 = model;
 
     ret = GTKTREEITER2RVAL(&iter);
-    G_CHILD_ADD(self, ret);
     return ret;
 }
 
@@ -317,7 +311,6 @@ rg_insert_after(VALUE self, VALUE sibling)
     iter.user_data3 = model;
 
     ret = GTKTREEITER2RVAL(&iter);
-    G_CHILD_ADD(self, ret);
     return ret;
 }
 
@@ -331,7 +324,6 @@ rg_prepend(VALUE self)
     iter.user_data3 = model;
 
     ret = GTKTREEITER2RVAL(&iter);
-    G_CHILD_ADD(self, ret);
     return ret;
 }
 
@@ -345,7 +337,6 @@ rg_append(VALUE self)
     iter.user_data3 = model;
 
     ret = GTKTREEITER2RVAL(&iter);
-    G_CHILD_ADD(self, ret);
     return ret;
 }
 

--- a/gtk2/ext/gtk2/rbgtktreemodel.c
+++ b/gtk2/ext/gtk2/rbgtktreemodel.c
@@ -54,7 +54,6 @@ rg_iter_first(VALUE self)
 
     if (ret) {
         val = GTKTREEITER2RVAL(&iter);
-        G_CHILD_ADD(self, val);
     }
 
     return val;
@@ -71,7 +70,6 @@ rg_iter_root(VALUE self)
 
     if (ret) {
         val = GTKTREEITER2RVAL(&iter);
-        G_CHILD_ADD(self, val);
     }
 
     return val;
@@ -85,7 +83,6 @@ rg_iter_next(VALUE self, VALUE iter)
 
     if (ret) {
         val = GTKTREEITER2RVAL(&iter);
-        G_CHILD_ADD(self, val);
     }
 
     return val;
@@ -110,7 +107,6 @@ rg_get_iter(VALUE self, VALUE path)
 
     if (ret) {
         val = GTKTREEITER2RVAL(&iter);
-        G_CHILD_ADD(self, val);
     }
 
     return val;

--- a/gtk2/test/test_gtk_list_store.rb
+++ b/gtk2/test/test_gtk_list_store.rb
@@ -62,4 +62,23 @@ class TestGtkListStore < Test::Unit::TestCase
     end
     assert_equal([2, 'she'], [iter[ID], iter[NAME]])
   end
+
+  def test_iter_gc
+    iterator_count = ObjectSpace.to_enum(:each_object, Gtk::TreeIter).to_a.size
+    50.times{ |i|
+      iter = @store.append
+      iter[ID] = i
+      iter[NAME] = i.to_s
+    }
+    100.times{
+      @store.iter_first
+    }
+    iter = @store.iter_first
+    while @store.remove(iter); end
+    iter = nil
+    assert_equal(0, @store.to_enum(:each).to_a.size)
+    ObjectSpace.garbage_collect
+    assert_equal(iterator_count, ObjectSpace.to_enum(:each_object, Gtk::TreeIter).to_a.size)
+  end
 end
+


### PR DESCRIPTION
日本語で失礼します。
gtk2の Gtk::ListStore が返す Gtk::TreeIter が、Rubyのコードから参照されていなくても開放されない問題を見つけたので、その修正と、問題を検証するためのテストを書きました。
サンプルコードなどで動作を検証して問題はないと考えたのですが、理解が浅いのでこれ以上の判断ができず、不具合の相談を兼ねて送らせていただきました。
