### PR TITLE
fix syntax error

### DIFF
--- a/gdk3/ext/gdk3/rbgdkevent.c
+++ b/gdk3/ext/gdk3/rbgdkevent.c
@@ -370,7 +370,7 @@ gdkevent_s_setting_get(int argc, VALUE *argv, G_GNUC_UNUSED VALUE self)
     VALUE value;
 
     rb_scan_args(argc, argv, "11", &name, &type);
-    if NIL_P(type) 
+    if (NIL_P(type))
         gtype = G_TYPE_STRING;
     else
         gtype = CLASS2GTYPE(type);

--- a/gdk3/ext/gdk3/rbgdkscreen.c
+++ b/gdk3/ext/gdk3/rbgdkscreen.c
@@ -214,7 +214,7 @@ rg_get_setting(int argc, VALUE *argv, VALUE self)
     VALUE value;
 
     rb_scan_args(argc, argv, "11", &name, &type);
-    if NIL_P(type) 
+    if (NIL_P(type))
         gtype = G_TYPE_STRING;
     else
         gtype = CLASS2GTYPE(type);

--- a/glib2/ext/glib2/rbglib_maincontext.c
+++ b/glib2/ext/glib2/rbglib_maincontext.c
@@ -652,7 +652,7 @@ static gint
 poll_func(GPollFD *ufds, guint nfsd, gint timeout_)
 {
     VALUE func = rb_ivar_get(self, id_poll_func);
-    if NIL_P(func) return -1;
+    if (NIL_P(func)) return -1;
 
     return INT2NUM(rb_funcall(func, 3, BOXED2RVAL(ufds, G_TYPE_POLL_FD),
                               UINT2NUM(nfsd), INT2NUM(timeout_)));

--- a/gtk2/ext/gtk2/rbgdkevent.c
+++ b/gtk2/ext/gtk2/rbgdkevent.c
@@ -387,7 +387,7 @@ gdkevent_s_setting_get(int argc, VALUE *argv, G_GNUC_UNUSED VALUE self)
     VALUE value;
 
     rb_scan_args(argc, argv, "11", &name, &type);
-    if NIL_P(type) 
+    if (NIL_P(type))
         gtype = G_TYPE_STRING;
     else
         gtype = CLASS2GTYPE(type);

--- a/gtk2/ext/gtk2/rbgdkscreen.c
+++ b/gtk2/ext/gtk2/rbgdkscreen.c
@@ -210,7 +210,7 @@ rg_get_setting(int argc, VALUE *argv, VALUE self)
     VALUE value;
 
     rb_scan_args(argc, argv, "11", &name, &type);
-    if NIL_P(type) 
+    if (NIL_P(type))
         gtype = G_TYPE_STRING;
     else
         gtype = CLASS2GTYPE(type);

--- a/gtk2/ext/gtk2/rbgtkcalendar.c
+++ b/gtk2/ext/gtk2/rbgtkcalendar.c
@@ -105,7 +105,7 @@ rg_display_options(int argc, VALUE *argv, VALUE self)
     VALUE flags;
     rb_scan_args(argc, argv, "01", &flags);
 
-    if NIL_P(flags){
+    if (NIL_P(flags)){
 #if GTK_CHECK_VERSION(2,4,0)
         return GFLAGS2RVAL(gtk_calendar_get_display_options(_SELF(self)),
                            GTK_TYPE_CALENDAR_DISPLAY_OPTIONS);


### PR DESCRIPTION
Ruby 2.0.0-rc2 で gtk2 のコンパイルが失敗したので、`if NIL_P(...)` を `if (NIL_P(...))` に修正しました。
