### PR TITLE
WebKitGtk2

### DIFF
--- a/webkit-gtk2/Rakefile
+++ b/webkit-gtk2/Rakefile
@@ -1,0 +1,25 @@
+$LOAD_PATH.unshift("./../glib2/lib")
+require 'gnome2-raketask'
+
+
+package = GNOME2Package.new do |_package|
+	_package.summary = "Ruby/WebKitGtk2 is a Ruby binding of WebKitGTK+ for Gtk 2.0 Toolkit"
+	_package.description = "Ruby/WebKitGtk2 is a Ruby binding of WebKitGTK+ for Gtk 2.0 Toolkit"
+	_package.dependency.gem.runtime = ["gobject-introspection","gtk2"]
+	_package.dependency.gem.development = ["test-unit-notify"]
+	_package.win32.packages = []
+	_package.win32.dependencies = []
+	_package.win32.build_dependencies = ["glib2", "gobject-introspection"]
+	_package.win32.build_packages = []
+end
+package.define_tasks
+
+
+namespace :dependency do
+	desc "Install dependencies"
+	task :install do
+		# TODO: Install gir1.2-webkit-1.0 on Debian.
+	end
+end
+
+task :build => "dependency:install"

--- a/webkit-gtk2/lib/webkit-gtk2.rb
+++ b/webkit-gtk2/lib/webkit-gtk2.rb
@@ -1,0 +1,31 @@
+require 'gobject-introspection'
+require 'gtk2'
+
+base_dir = Pathname.new(__FILE__).dirname.dirname.dirname.expand_path
+vendor_dir = base_dir + "vendor" + "local"
+vendor_bin_dir = vendor_dir + "bin"
+GLib.prepend_environment_path(vendor_bin_dir)
+
+module WebKitGtk2
+	@initialized = false
+	class << self
+		def init
+			return if @initialized
+			@initialized = true
+			loader = Loader.new(self)
+			loader.load("WebKit","1.0")
+		end
+	end
+
+	class Loader < GObjectIntrospection::Loader
+		def load(namespace,version=nil)
+			repository = GObjectIntrospection::Repository.default
+			repository.require(namespace,version)
+			pre_load(repository,namespace)
+			repository.each(namespace) do |info|
+				load_info(info)
+			end
+			post_load(repository,namespace)
+		end
+	end
+end

--- a/webkit-gtk2/sample/brower.rb
+++ b/webkit-gtk2/sample/brower.rb
@@ -1,0 +1,20 @@
+require 'webkit-gtk2'
+
+WebKitGtk2.init
+
+window = Gtk::Window.new
+window.signal_connect("destroy") do
+	Gtk.main_quit
+end
+
+
+sw = Gtk::ScrolledWindow.new
+
+view = WebKitGtk2::WebView.new
+view.load_uri("http://webkitgtk.org/")
+
+sw.add(view)
+window.add(sw)
+window.show_all
+
+Gtk.main

--- a/webkit-gtk2/test/run-test.rb
+++ b/webkit-gtk2/test/run-test.rb
@@ -1,0 +1,58 @@
+#!/usr/bin/env ruby
+#
+# Copyright (C) 2013  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+ruby_gnome2_base = File.join(File.dirname(__FILE__), "..", "..")
+ruby_gnome2_base = File.expand_path(ruby_gnome2_base)
+
+glib_base = File.join(ruby_gnome2_base, "glib2")
+gio_base = File.join(ruby_gnome2_base, "gio2")
+atk_base = File.join(ruby_gnome2_base, "atk")
+pango_base = File.join(ruby_gnome2_base, "pango")
+gdk2_base = File.join(ruby_gnome2_base, "gdk2")
+gtk2_base = File.join(ruby_gnome2_base, "gtk2")
+gobject_introspection_base = File.join(ruby_gnome2_base, "gobject-introspection")
+
+modules = [
+  [glib_base, "glib2"],
+  [gio_base, "gio2"],
+  [atk_base, "atk"],
+  [pango_base, "pango"],
+  [gdk3_base, "gdk2"],
+  [gtk3_base, "gtk2"],
+  [gobject_introspection_base, "gobject-introspection"],
+]
+modules.each do |target, module_name|
+  if system("which make > /dev/null")
+    `make -C #{target.dump} > /dev/null` or exit(false)
+  end
+  $LOAD_PATH.unshift(File.join(target, "ext", module_name))
+  $LOAD_PATH.unshift(File.join(target, "lib"))
+end
+
+$LOAD_PATH.unshift(File.join(glib_base, "test"))
+require "glib-test-init"
+
+$LOAD_PATH.unshift(File.join(gobject_introspection_base, "test"))
+require "gobject-introspection-test-utils"
+
+$LOAD_PATH.unshift(File.join(clutter_base, "test"))
+require "webkit-gtk-test-utils"
+
+require "webkit-gtk"
+
+exit Test::Unit::AutoRunner.run(true)

--- a/webkit-gtk2/test/webkit-gtk-test-utils.rb
+++ b/webkit-gtk2/test/webkit-gtk-test-utils.rb
@@ -1,0 +1,21 @@
+# Copyright (C) 2013  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+require "test-unit"
+require "test/unit/notify"
+
+module WebKitGtkTestUtils
+end


### PR DESCRIPTION
Created GObjectIntrospection bindings for WebKitGtk specifically for use with Gtk2, instead of Gtk3.
