### PR TITLE
goocanvas sample: use more specific name

### DIFF
--- a/goocanvas/sample/goocanvas-gi.rb
+++ b/goocanvas/sample/goocanvas-gi.rb
@@ -20,7 +20,7 @@ require "gobject-introspection"
 base_dir = Pathname.new(__FILE__).dirname.dirname.dirname.expand_path
 vendor_dir = base_dir + "vendor" + "local"
 vendor_bin_dir = vendor_dir + "bin"
-GLib.prepend_environment_path(vendor_bin_dir)
+GLib.prepend_dll_path(vendor_bin_dir)
 
 module Goo
   LOG_DOMAIN = "GooCanvas"


### PR DESCRIPTION
Fix undefined method `prepend_environment_path'

ref: commit 510a0c216688d0209ecd5c8ec33e8eeaab3a07ee
