### PR TITLE
Fixed type conversion from VALUE to GType

### DIFF
--- a/gobject-introspection/ext/gobject-introspection/rb-gi-loader.c
+++ b/gobject-introspection/ext/gobject-introspection/rb-gi-loader.c
@@ -121,7 +121,7 @@ rg_s_register_boxed_class_converter(VALUE klass, VALUE rb_gtype)
 
     memset(&table, 0, sizeof(RGConvertTable));
     CONST_ID(id_to_i, "to_i");
-    table.type = NUM2UINT(rb_funcall(rb_gtype, id_to_i, 0));
+    table.type = NUM2ULONG(rb_funcall(rb_gtype, id_to_i, 0));
     table.klass = Qnil;
     table.instance2robj = boxed_instance2robj;
 

--- a/gobject-introspection/ext/gobject-introspection/rb-gi-struct-info.c
+++ b/gobject-introspection/ext/gobject-introspection/rb-gi-struct-info.c
@@ -71,7 +71,7 @@ rg_get_field_value(VALUE self, VALUE rb_struct, VALUE rb_n)
         VALUE rb_gtype;
         GType gtype;
         rb_gtype = rb_funcall(rb_struct, rb_intern("gtype"), 0);
-        gtype = NUM2UINT(rb_funcall(rb_gtype, rb_intern("to_i"), 0));
+        gtype = NUM2ULONG(rb_funcall(rb_gtype, rb_intern("to_i"), 0));
         instance = RVAL2BOXED(rb_struct, gtype);
     } else {
         Data_Get_Struct(rb_struct, void, instance);


### PR DESCRIPTION
- bug fix for the following errors
  - clutter/lib/clutter.rb:123:in `register_boxed_class_converter': integer 140532096032688 too big to convert to`unsigned int' (RangeError)
  - gobject-introspection/lib/gobject-introspection/loader.rb:177:in `get_field_value': integer 140479269924112 too big to convert to`unsigned int'
