### PR TITLE
poppler: backport event sub classes from gtk2/

### DIFF
--- a/poppler/ext/poppler/poppler.def
+++ b/poppler/ext/poppler/poppler.def
@@ -1,2 +1,4 @@
 EXPORTS
     Init_poppler
+    rb_poppler_action2rval
+    rb_poppler_rval2poppler_action_event

--- a/poppler/ext/poppler/rbpoppler.h
+++ b/poppler/ext/poppler/rbpoppler.h
@@ -54,8 +54,8 @@ extern PopplerColor *rb_poppler_ruby_object_to_color(VALUE color);
 extern VALUE rb_poppler_ruby_object_from_color_with_free(PopplerColor *color);
 #endif
 
-extern VALUE rb_poppler_ruby_object_from_action(PopplerAction *action);
-extern PopplerAction *rb_poppler_action_from_ruby_object(VALUE action);
 extern VALUE rb_poppler_ruby_object_from_form_field(PopplerFormField *field);
+extern VALUE rb_poppler_action2rval(PopplerAction *event);
+extern PopplerAction *rb_poppler_rval2poppler_action_event(VALUE event);
 
 #endif

--- a/poppler/ext/poppler/rbpopplerconversions.h
+++ b/poppler/ext/poppler/rbpopplerconversions.h
@@ -23,8 +23,8 @@
 
 #define POPPLERANNOT2RVAL(o)                    (GOBJ2RVAL(o))
 #define POPPLERFORMFIELD2RVAL(o)                (rb_poppler_ruby_object_from_form_field(o))
-#define RVAL2POPPLERACTION(o)                   (rb_poppler_action_from_ruby_object(o))
-#define POPPLERACTION2RVAL(o)                   (rb_poppler_ruby_object_from_action(o))
+#define RVAL2POPPLERACTION(o)                   (rb_poppler_rval2poppler_action_event(o))
+#define POPPLERACTION2RVAL(o)                   (rb_poppler_action2rval(o))
 #define RVAL2POPPLERCOLOR(o)                    (rb_poppler_ruby_object_to_color(o))
 #define POPPLERCOLOR2RVAL(o)                    (BOXED2RVAL(o, POPPLER_TYPE_COLOR))
 #define POPPLERCOLOR2RVAL_FREE(o)               (rb_poppler_ruby_object_from_color_with_free(o))


### PR DESCRIPTION
- backport event subclasses from gtk2 https://github.com/ruby-gnome2/ruby-gnome2/commit/753593e2363c793b238a817b44b430a066780eeb
