### PR TITLE
gobject-introspection: raise require gi version to run SignalFlags assertion

### DIFF
--- a/gobject-introspection/test/test-signal-info.rb
+++ b/gobject-introspection/test/test-signal-info.rb
@@ -25,7 +25,7 @@ class TestSignalInfo < Test::Unit::TestCase
   end
 
   def test_flags
-    require_version(1, 38, 0)
+    require_version(1, 39, 0)
     assert_equal(GLib::SignalFlags::RUN_LAST,
                  @info.flags)
   end


### PR DESCRIPTION
``` log
F
===============================================================================
Failure:
test_flags(TestSignalInfo)
/home/cosmo/Github/ruby-gnome2/gobject-introspection/test/test-signal-info.rb:29:in
`test_flags'
     26:
     27:   def test_flags
     28:     require_version(1, 38, 0)
  => 29:     assert_equal(GLib::SignalFlags::RUN_LAST,
     30:                  @info.flags)
     31:   end
     32:
<#<GLib::SignalFlags run-last>> expected but was
<#<GLib::SignalFlags run-cleanup>>

diff:
? #<GLib::SignalFlags run- l ast >
?                         c e nup
===============================================================================
```
