### PR TITLE
gtksourceview2 suppress previous definition warnings

### DIFF
--- a/glib2/ext/glib2/rbgutil.h
+++ b/glib2/ext/glib2/rbgutil.h
@@ -70,6 +70,8 @@ extern "C" {
     G_REPLACE_SET_PROPERTY(RG_TARGET_NAMESPACE, #name, rg_set_ ## name, args)
 #define RG_REPLACE_GET_PROPERTY(name, args)   \
     G_REPLACE_GET_PROPERTY(RG_TARGET_NAMESPACE, #name, rg_get_ ## name, args)
+#define RG_REPLACE_ACTION(name, args)                               \
+    G_REPLACE_ACTION(RG_TARGET_NAMESPACE, #name, rg_ ## name, args)
 
 #define G_REPLACE_SET_PROPERTY(klass, name, function, args) \
     rb_undef_method(klass, "set_" name); \

--- a/gtksourceview2/ext/gtksourceview2/rbgtksourceiter.c
+++ b/gtksourceview2/ext/gtksourceview2/rbgtksourceiter.c
@@ -108,8 +108,8 @@ Init_gtk_sourceiter (VALUE mGtk)
     /*
      * They are override original Gtk::TextIter#[for|back]ward_search
      */
-    RG_DEF_METHOD(forward_search, -1);
-    RG_DEF_METHOD(backward_search, -1);
+    RG_REPLACE_ACTION(forward_search, -1);
+    RG_REPLACE_ACTION(backward_search, -1);
 
     G_DEF_CLASS(GTK_TYPE_SOURCE_SEARCH_FLAGS, "SourceSearchFlags", RG_TARGET_NAMESPACE);
     G_DEF_CONSTANTS(RG_TARGET_NAMESPACE, GTK_TYPE_SOURCE_SEARCH_FLAGS, "GTK_");


### PR DESCRIPTION
`Gtk::TextIter#forward_search` and `Gtk::TextIter#backward_search` are override original `Gtk::TextIter#[for|back]ward_search`.
- add `RG_REPLACE_ACTION` macro to redefine method and to suppress warning.
