### PR TITLE
glib2: using "-Werror" to check whether it can use compiler option

### DIFF
--- a/glib2/lib/mkmf-gnome2.rb
+++ b/glib2/lib/mkmf-gnome2.rb
@@ -22,12 +22,6 @@ def try_compiler_option(opt, &block)
   end
 end
 
-def try_compiler_option_strictly(opt, &block)
-  checking_for "#{opt} option to compiler" do
-    $CFLAGS += " #{opt}" if try_compile '', opt + " -Werror", &block
-  end
-end
-
 try_compiler_option '-Wall'
 try_compiler_option '-Waggregate-return'
 try_compiler_option '-Wcast-align'
@@ -58,8 +52,8 @@ try_compiler_option '-Wswitch-enum'
 try_compiler_option '-Wundef'
 # NOTE: Incredible amounts of false positives.
 #try_compiler_option '-Wunreachable-code'
-try_compiler_option_strictly '-Wout-of-line-declaration'
-try_compiler_option_strictly '-Wunsafe-loop-optimizations'
+try_compiler_option '-Wout-of-line-declaration'
+try_compiler_option '-Wunsafe-loop-optimizations'
 try_compiler_option '-Wwrite-strings'
 
 if /-Wl,--no-undefined/ =~ $LDFLAGS.to_s


### PR DESCRIPTION
In recent OSX, default compiler of Command Line Tools 4.0 or higher is clang.
So, '-Wout-of-line-declaration' causes flood of warnings as follows:

```
warning: unknown warning option '-Wunsafe-loop-optimizations'; did you
mean
      '-Wout-of-line-declaration'? [-Wunknown-warning-option]
```
