### PR TITLE
gtk3: add Gtk::Window#set_titlebar (enable the use of Gtk::HeaderBar)

### DIFF
--- a/gtk3/ext/gtk3/rbgtk-window.c
+++ b/gtk3/ext/gtk3/rbgtk-window.c
@@ -485,6 +485,13 @@ rg_set_default_geometry(VALUE self, VALUE width, VALUE height)
     return self;
 }
 
+static VALUE
+rg_set_titlebar(VALUE self, VALUE titlebar)
+{
+    gtk_window_set_titlebar(_SELF(self), RVAL2GTKWIDGET(titlebar));
+    return self;
+}
+
 void
 Init_gtk_window(VALUE mGtk)
 {
@@ -544,6 +551,7 @@ Init_gtk_window(VALUE mGtk)
     RG_DEF_METHOD(propagate_key_event, 1);
     RG_DEF_METHOD(resize_to_geometry, 2);
     RG_DEF_METHOD(set_default_geometry, 2);
+    RG_DEF_METHOD(set_titlebar, 1);
 
     G_DEF_CLASS(GTK_TYPE_WINDOW_POSITION, "Position", RG_TARGET_NAMESPACE);
     G_DEF_CLASS(GTK_TYPE_WINDOW_TYPE, "Type", RG_TARGET_NAMESPACE);


### PR DESCRIPTION
Adds the #set_titlebar method to Gtk::Window.
Without this, having Gtk::HeaderBar seems useless because I cannot find a way to actually use it.

I compiled and tested this with gnome-shell 3.12 and had no issue.
