### PR TITLE
fix links in READMEs ruby-gnome2 -> ruby-gnome

### DIFF
--- a/atk/README.md
+++ b/atk/README.md
@@ -4,8 +4,8 @@ Ruby/ATK is a Ruby binding of ATK-1.12.x or later based on GObject-Introspection
 
 ## Requirements
 
-* [Ruby/GObject-Introspection](https://github.com/ruby-gnome2/ruby-gnome2)
-* [Ruby/GLib2](https://github.com/ruby-gnome2/ruby-gnome2)
+* [Ruby/GObject-Introspection](https://github.com/ruby-gnome/ruby-gnome)
+* [Ruby/GLib2](https://github.com/ruby-gnome/ruby-gnome)
 
 ## Install
 
@@ -21,4 +21,4 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 ## Project Websites
 
 *   https://ruby-gnome2.osdn.jp/
-*   https://github.com/ruby-gnome2/ruby-gnome2
+*   https://github.com/ruby-gnome/ruby-gnome

--- a/clutter-gdk/README.md
+++ b/clutter-gdk/README.md
@@ -25,5 +25,5 @@ https://developer.gnome.org/clutter/stable/clutter-GDK-Specific-Support.html
 
 ## Project Websites
 
-*  https://github.com/ruby-gnome2/ruby-gnome2
+*  https://github.com/ruby-gnome/ruby-gnome
 *  https://ruby-gnome2.osdn.jp/

--- a/gdk_pixbuf2/README.md
+++ b/gdk_pixbuf2/README.md
@@ -27,4 +27,4 @@ Copying
 Project Websites
 ----------------
 * https://ruby-gnome2.osdn.jp/
-* https://github.com/ruby-gnome2/ruby-gnome2
+* https://github.com/ruby-gnome/ruby-gnome

--- a/gnumeric/README.md
+++ b/gnumeric/README.md
@@ -22,4 +22,4 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 ## Project Websites
 
 *   https://ruby-gnome2.osdn.jp/
-*   https://github.com/ruby-gnome2/ruby-gnome2
+*   https://github.com/ruby-gnome/ruby-gnome

--- a/goffice/README.md
+++ b/goffice/README.md
@@ -22,4 +22,4 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 ## Project Websites
 
 *   https://ruby-gnome2.osdn.jp/
-*   https://github.com/ruby-gnome2/ruby-gnome2
+*   https://github.com/ruby-gnome/ruby-gnome

--- a/gsf/README.md
+++ b/gsf/README.md
@@ -22,4 +22,4 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 ## Project Websites
 
 *   https://ruby-gnome2.osdn.jp/
-*   https://github.com/ruby-gnome2/ruby-gnome2
+*   https://github.com/ruby-gnome/ruby-gnome

--- a/gtk3/README.md
+++ b/gtk3/README.md
@@ -30,5 +30,5 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 
 ## Project Websites
 
-* https://github.com/ruby-gnome2/ruby-gnome2
+* https://github.com/ruby-gnome/ruby-gnome
 * https://ruby-gnome2.osdn.jp/

--- a/gtk4/README.md
+++ b/gtk4/README.md
@@ -28,5 +28,5 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 
 ## Project Websites
 
-* https://github.com/ruby-gnome2/ruby-gnome2
+* https://github.com/ruby-gnome/ruby-gnome
 * https://ruby-gnome2.osdn.jp/

--- a/pango/README.md
+++ b/pango/README.md
@@ -4,8 +4,8 @@ Ruby/Pango is a Ruby binding of pango based on GObject-Introspection.
 
 ## Requirements
 
-* [Ruby/GObject-Introspection](https://github.com/ruby-gnome2/ruby-gnome2)
-* [Ruby/GLib2](https://github.com/ruby-gnome2/ruby-gnome2)
+* [Ruby/GObject-Introspection](https://github.com/ruby-gnome/ruby-gnome)
+* [Ruby/GLib2](https://github.com/ruby-gnome/ruby-gnome)
 * [cairo/rcairo](http://cairographics.org/)
 
 ## Install
@@ -22,4 +22,4 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 ## Project Websites
 
 *   https://ruby-gnome2.osdn.jp/
-*   https://github.com/ruby-gnome2/ruby-gnome2
+*   https://github.com/ruby-gnome/ruby-gnome

--- a/poppler/README.md
+++ b/poppler/README.md
@@ -4,8 +4,8 @@ Ruby/Poppler is a Ruby binding of [poppler-glib](https://developer.gnome.org/pop
 
 ## Requirements
 
-* [Ruby/GObject-Introspection](https://github.com/ruby-gnome2/ruby-gnome2)
-* [Ruby/Gio2](https://github.com/ruby-gnome2/ruby-gnome2)
+* [Ruby/GObject-Introspection](https://github.com/ruby-gnome/ruby-gnome)
+* [Ruby/Gio2](https://github.com/ruby-gnome/ruby-gnome)
 * [rcairo](https://github.com/rcairo/rcairo)
 
 ## Install
@@ -22,4 +22,4 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 ## Project Websites
 
 *   https://ruby-gnome2.osdn.jp/
-*   https://github.com/ruby-gnome2/ruby-gnome2
+*   https://github.com/ruby-gnome/ruby-gnome

--- a/rsvg2/README.md
+++ b/rsvg2/README.md
@@ -4,9 +4,9 @@ Ruby/RSVG2 is a Ruby binding of [librsvg](https://developer.gnome.org/rsvg/) bas
 
 ## Requirements
 
-* [Ruby/GObject-Introspection](https://github.com/ruby-gnome2/ruby-gnome2)
-* [Ruby/GLib2](https://github.com/ruby-gnome2/ruby-gnome2)
-* [Ruby/Gdk_pixbuf2](https://github.com/ruby-gnome2/ruby-gnome2)
+* [Ruby/GObject-Introspection](https://github.com/ruby-gnome/ruby-gnome)
+* [Ruby/GLib2](https://github.com/ruby-gnome/ruby-gnome)
+* [Ruby/Gdk_pixbuf2](https://github.com/ruby-gnome/ruby-gnome)
 * [cairo/rcairo](http://cairographics.org/)
 
 ## Install
@@ -23,4 +23,4 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 ## Project Websites
 
 * https://ruby-gnome2.osdn.jp/
-* https://github.com/ruby-gnome2/ruby-gnome2
+* https://github.com/ruby-gnome/ruby-gnome


### PR DESCRIPTION
Replace all Ruby-gnome 2 links in README with Ruby-Gnome