### PR TITLE
glib2: fix parser in MkEnums for resent GLib

### DIFF
--- a/glib2/lib/glib-mkenums.rb
+++ b/glib2/lib/glib-mkenums.rb
@@ -112,7 +112,10 @@ GType #{@enum_name}_get_type (void);
       data.force_encoding("utf-8") if data.respond_to?(:force_encoding)
       data.scan(/^\s*typedef\s+enum\s*(\/\*<\s*flags\s*>\*\/)?\s*
                 \{?\s*(.*?)
-                \}\s*(\w+)\s*([\w\(\)]*);/mx) do |force_flags, constants, name, deprecation_flag|
+                \}\s*(\w+)
+                # GLIB_DEPRECATED_TYPE_IN_2_38_FOR(GTestSubprocessFlags)
+                (?:\s+[\w()\s]+)?
+                ;/mx) do |force_flags, constants, name|
         enum_options = {}
         enum_options[:force_flags] = !force_flags.nil?
         force_flags_patterns = [(options[:force_flags] || [])].flatten

--- a/glib2/lib/glib-mkenums.rb
+++ b/glib2/lib/glib-mkenums.rb
@@ -112,7 +112,7 @@ GType #{@enum_name}_get_type (void);
       data.force_encoding("utf-8") if data.respond_to?(:force_encoding)
       data.scan(/^\s*typedef\s+enum\s*(\/\*<\s*flags\s*>\*\/)?\s*
                 \{?\s*(.*?)
-                \}\s*(\w+);/mx) do |force_flags, constants, name|
+                \}\s*(\w+)\s*([\w\(\)]*);/mx) do |force_flags, constants, name, deprecation_flag|
         enum_options = {}
         enum_options[:force_flags] = !force_flags.nil?
         force_flags_patterns = [(options[:force_flags] || [])].flatten


### PR DESCRIPTION
GLib 2.62.0 introduced some deprecation warnings for macros in gtestutils.h with the commit https://gitlab.gnome.org/GNOME/glib/commit/40ff4759774516b7dff3b07303a98fc1626b2d0e .
This patch makes GLib::MkEnums correctly parse header files in GLib 2.62.0 again.

Fixes https://github.com/ruby-gnome/ruby-gnome/issues/1294