### PR TITLE
Add Ubuntu package name for gtksourceview4

### DIFF
--- a/gtksourceview4/dependency-check/Rakefile
+++ b/gtksourceview4/dependency-check/Rakefile
@@ -33,6 +33,7 @@ namespace :dependency do
     unless PKGConfig.check_version?(package_id)
       unless NativePackageInstaller.install(:altlinux => "libgtksourceview4-devel",
                                             :debian => "libgtksourceview-4.0-dev",
+                                            :ubuntu => "libgtksourceview-4-dev",
                                             :redhat => "pkgconfig(#{package_id})",
                                             :homebrew => "gtksourceview4",
                                             :macports => "gtksourceview4",


### PR DESCRIPTION
It is `libgtksourceview-4-dev`, not `libgtksourceview-4.0-dev` as for Debian.