### PR TITLE
gtk3: fix cursor example

### DIFF
--- a/gtk3/sample/misc/cursor.rb
+++ b/gtk3/sample/misc/cursor.rb
@@ -15,20 +15,20 @@ window.realize
 button = Gtk::Button.new(:label => "Click!")
 button.use_underline = false
 
-cursors = Gdk::CursorType.values - [Gdk::CursorType::CURSOR_IS_PIXMAP]
-cursors -= [Gdk::CursorType::LAST_CURSOR]
+cursors = Gdk::CursorType.values -
+          [Gdk::CursorType::CURSOR_IS_PIXMAP] -
+          [Gdk::CursorType::LAST_CURSOR]
+cursors = cursors.cycle
 
-cnt = 0
 button.signal_connect('clicked') do
-  cursor = cursors[cnt]
+  cursor = cursors.next
   p cursor
   button.set_label(cursor.inspect)
   window.window.set_cursor(Gdk::Cursor.new(cursor))
-  cnt += 1
-  cnt = 0 if cnt == cursors.size
 end
+
 window.add(button)
-window.set_default_size(400,100)
+window.set_default_size(400, 100)
 window.show_all
 
 Gtk.main

--- a/gtk3/sample/misc/cursor.rb
+++ b/gtk3/sample/misc/cursor.rb
@@ -2,8 +2,8 @@
   cursor.rb - Gdk::Cursor sample script.
 
   Copyright (C) 2001-2006 Masao Mutoh
-  Copyright (c) 2002-2015 Ruby-GNOME2 Project Team
-  This program is licenced under the same licence as Ruby-GNOME2.
+  Copyright (c) 2002-2020 Ruby-GNOME Project Team
+  This program is licenced under the same licence as Ruby-GNOME.
 =end
 
 require "gtk3"
@@ -21,7 +21,7 @@ cursors -= [Gdk::CursorType::LAST_CURSOR]
 cnt = 0
 button.signal_connect('clicked') do
   cursor = cursors[cnt]
-p cursor.inspect
+  p cursor
   button.set_label(cursor.inspect)
   window.window.set_cursor(Gdk::Cursor.new(cursor))
   cnt += 1


### PR DESCRIPTION
34afac0 
* Fix incorrect indentation
* Remove needless inspect
* Update copyright year

b415989
* Use cycle

If you don't like b415989, please omit it.