### PR TITLE
gtk3: fix eventbox example

### DIFF
--- a/gtk3/sample/misc/eventbox.rb
+++ b/gtk3/sample/misc/eventbox.rb
@@ -1,8 +1,8 @@
 =begin
   eventbox.rb - Ruby/GTK sample script.
 
-  Copyright (c) 2015 Ruby-GNOME2 Project Team
-  This program is licenced under the same licence as Ruby-GNOME2.
+  Copyright (c) 2015-2020 Ruby-GNOME Project Team
+  This program is licenced under the same licence as Ruby-GNOME.
 =end
 
 # https://developer.gnome.org/gtk3/unstable/GtkEventBox.html
@@ -31,7 +31,9 @@ cr.set_source_rgb(0, 0, 1)
 cr.rectangle(*r3)
 cr.fill
 
-image = Gtk::Image.new(:pixbuf => surface.to_pixbuf(0, 0, 265, 95))
+image = Gtk::Image.new(
+  pixbuf: surface.to_pixbuf(src_x: 0, src_y: 0, width: 265, height: 95)
+)
 
 event_box = Gtk::EventBox.new
 

--- a/gtk3/sample/misc/eventbox.rb
+++ b/gtk3/sample/misc/eventbox.rb
@@ -42,11 +42,11 @@ event_box.add(image)
 event_box.signal_connect "button-press-event" do |_widget, event|
   if event.y >= 10 && event.y <= 85
     if event.x >= 10 && event.x <= 85
-      puts "red x = #{event.x} y = #{event.y}"
+      puts "red   x = #{event.x} \t y = #{event.y}"
     elsif event.x >= 95 && event.x <= 180
-      puts "green x = #{event.x} y = #{event.y}"
+      puts "green x = #{event.x} \t y = #{event.y}"
     elsif event.x >= 190 && event.x <= 255
-      puts "blue x = #{event.x} y = #{event.y}"
+      puts "blue  x = #{event.x} \t y = #{event.y}"
     end
   end
 end


### PR DESCRIPTION
3000d4e 

* Fix a warning
    ```
    eventbox.rb:34:in `<main>': 'Cairo::Surface#to_pixbuf(src_x, src_y, width, height)' style has been deprecated. Use 'Cairo::Surface#to_pixbuf(:src_x => 0, :src_y => 0, :width => width, :height => height)' style.
    ```
* Update copyright year

f6f7d39

* Improve output
    * before
         ![image](https://user-images.githubusercontent.com/5798442/74242733-cbff7f00-4d21-11ea-896d-a1cef35195ba.png)

    * after
        ![image](https://user-images.githubusercontent.com/5798442/74242769-dae63180-4d21-11ea-989e-663d053c07fd.png)


If you don't like f6f7d39, please omit it.