### PR TITLE
gtk3: fix flowbox example

### DIFF
--- a/gtk3/sample/misc/flowbox.rb
+++ b/gtk3/sample/misc/flowbox.rb
@@ -44,7 +44,7 @@ class FlowBoxWindow < Gtk::Window
     set_titlebar(header)
 
     scrolled = Gtk::ScrolledWindow.new
-    scrolled.set_policy(Gtk::PolicyType::NEVER, Gtk::PolicyType::AUTOMATIC)
+    scrolled.set_policy(:never, :automatic)
 
     flowbox = Gtk::FlowBox.new
     flowbox.valign = :start

--- a/gtk3/sample/misc/flowbox.rb
+++ b/gtk3/sample/misc/flowbox.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 #
 # Copyright (c)  2014  Gian Mario Tagliaretti
-# Copyright (c)  2015-2018  Ruby-GNOME2 Project Team
+# Copyright (c)  2015-2020  Ruby-GNOME Project Team
 #
 # Permission is granted to copy, distribute and/or modify this document
 # under the terms of the GNU Free Documentation License, Version 1.3
@@ -73,7 +73,7 @@ class FlowBoxWindow < Gtk::Window
     area.signal_connect("draw") do |_, context|
       context.set_source_rgba(color)
       context.paint
-    end 
+    end
 
     button.add(area)
   end


### PR DESCRIPTION
8b623c4 

* Update copyright year
* Remove a needless space

21fbd76 

* Use symbols

If you don't like 21fbd76, please omit it. 