### PR TITLE
gtk3: improve image example

### DIFF
--- a/gtk3/sample/misc/image.rb
+++ b/gtk3/sample/misc/image.rb
@@ -2,42 +2,28 @@
 =begin
   image.rb - Ruby/GTK sample script.
 
-  Copyright (c) 2002-2015 Ruby-GNOME2 Project Team
-  This program is licenced under the same licence as Ruby-GNOME2.
+  Copyright (c) 2002-2020 Ruby-GNOME Project Team
+  This program is licenced under the same licence as Ruby-GNOME.
 =end
 
 require "gtk3"
 
 window = Gtk::Window.new("Image")
-window.signal_connect("destroy") do
-  Gtk.main_quit
-end
-window.border_width = 0
-
-box1 = Gtk::Box.new(:vertical, 10)
-box1.border_width = 10
+window.signal_connect("destroy") { Gtk.main_quit }
+window.border_width = 10
 
 button = Gtk::Button.new
-box1.add(button)
 
-label = Gtk::Label.new("Gtk::Image\ntest")
+label = Gtk::Label.new("Gtk::Image")
 image = Gtk::Image.new(:file => "test.xpm")
 
-box2 = Gtk::Box.new(:horizontal, 5)
-box2.add(image)
-box2.add(label)
+box = Gtk::Box.new(:horizontal, 5)
+box.add(image)
+box.add(label)
 
-button.add(box2)
+button.add(box)
 
-box1.add(Gtk::Separator.new(:horizontal))
-
-button = Gtk::Button.new(:label => "close")
-button.signal_connect("clicked") do
-  Gtk.main_quit
-end
-box1.add(button)
-
-window.add(box1)
+window.add(button)
 window.show_all
 
 Gtk.main


### PR DESCRIPTION
* Update copyright year
* Remove the unnecessary elements to make it clear how users display the image file with Ruby/Gtk. 
    * The two buttons have the same name. This is a bit weird. Maybe we don't need a second button.
* Remove "test". Because this is not a test...

before
![image](https://user-images.githubusercontent.com/5798442/74342808-6c6ea580-4ded-11ea-8b31-0ee6f5f49274.png)

after
![image](https://user-images.githubusercontent.com/5798442/74342870-87d9b080-4ded-11ea-8347-d0383f559301.png)
