### PR TITLE
vte3: fix spawn arguments

### DIFF
--- a/vte3/lib/vte3/terminal.rb
+++ b/vte3/lib/vte3/terminal.rb
@@ -1,4 +1,4 @@
-# Copyright (C) 2015  Ruby-GNOME2 Project Team
+# Copyright (C) 2015-2020  Ruby-GNOME Project Team
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -44,7 +44,7 @@ module Vte
         pty_object
       end
     else
-      def spawn(options)
+      def spawn(options={})
         pty_flags = options[:pty_flags] || PtyFlags::DEFAULT
         working_directory = options[:working_directory]
         argv = options[:argv] || [ENV["SHELL"] || "/bin/sh"]

--- a/vte3/sample/terminal.rb
+++ b/vte3/sample/terminal.rb
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+=begin
+  terminal.rb - Ruby/VTE3 sample script.
+
+  Copyright (c) 2006-2020 Ruby-GNOME Project Team
+  This program is licenced under the same licence as Ruby-GNOME.
+
+  $Id: terminal.rb,v 1.2 2006/06/17 13:27:51 mutoh Exp $
+=end
+
+require "vte3"
+
+window = Gtk::Window.new("Terminal sample")
+window.signal_connect("destroy"){ Gtk.main_quit }
+
+terminal = Vte::Terminal.new
+terminal.signal_connect("child-exited") do |_widget|
+  Gtk.main_quit
+end
+terminal.signal_connect("window-title-changed") do |_widget|
+  window.title = terminal.window_title
+end
+terminal.spawn
+window.add(terminal)
+window.show_all
+
+Gtk.main


### PR DESCRIPTION
* Update copyright year
* Allow spawn to accept no arguments

```ruby
require 'vte3'
terminal = Vte::Terminal.new
terminal.spawn
```

```
        5: from /home/kojix2/.rbenv/versions/2.7.0/bin/irb:23:in `<main>'
        4: from /home/kojix2/.rbenv/versions/2.7.0/bin/irb:23:in `load'
        3: from /home/kojix2/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/irb-1.2.1/exe/irb:11:in `<top (required)>'
        2: from (irb):20
        1: from /home/kojix2/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/vte3-3.4.1/lib/vte3/terminal.rb:47:in `spawn'
ArgumentError (wrong number of arguments (given 0, expected 1))
```

* Import an example from vte