### PR TITLE
gdk_pixbuf2: fix anim example

### DIFF
--- a/gdk_pixbuf2/sample/anim.rb
+++ b/gdk_pixbuf2/sample/anim.rb
@@ -2,35 +2,35 @@
 =begin
   anim.rb - Ruby/GdkPixbuf sample script.
 
-  Copyright (c) 2002-2016 Ruby-GNOME2 Project Team
-  This program is licenced under the same licence as Ruby-GNOME2.
+  Copyright (c) 2002-2020 Ruby-GNOME Project Team
+  This program is licenced under the same licence as Ruby-GNOME.
 
   $Id: anim.rb,v 1.5 2006/06/17 14:38:08 mutoh Exp $
 =end
 
-require 'gtk2'
+require 'gtk3'
 
 w = Gtk::Window.new
 w.signal_connect('delete-event') do
   Gtk.main_quit
 end
 
-box = Gtk::VBox.new
-src =  GdkPixbuf::PixbufAnimation.new(File.join(__dir__, "floppybuddy.gif"))
-box.pack_start(Gtk::Image.new(src))
+box = Gtk::Box.new(:vertical)
+src = GdkPixbuf::PixbufAnimation.new(File.join(__dir__, "floppybuddy.gif"))
+box.pack_start(Gtk::Image.new(animation: src))
 p src.width
 p src.height
 p src.static_image?
 
 static_image = src.static_image
-box.pack_start(Gtk::Image.new(static_image))
+box.pack_start(Gtk::Image.new(pixbuf: static_image))
 
 iter = src.get_iter
 p iter.advance
 p iter.delay_time
 p iter.on_currently_loading_frame?
 
-box.pack_start(Gtk::Image.new(iter.pixbuf))
+box.pack_start(Gtk::Image.new(pixbuf: iter.pixbuf))
 
 w.add(box)
 w.show_all


### PR DESCRIPTION
* Update copyright year
* Use gtk3 instead of gtk2
* VBox -> Box.new(:vertical)
* Remove a needless space
* Fix Gtk::Image#new arguments