### PR TITLE
gdk_pixbuf2: fix format example

### DIFF
--- a/gdk_pixbuf2/sample/format.rb
+++ b/gdk_pixbuf2/sample/format.rb
@@ -2,19 +2,13 @@
 =begin
   format.rb - Ruby/GdkPixbuf sample script.
 
-  Copyright (c) 2004-2016 Ruby-GNOME2 Project Team
-  This program is licenced under the same licence as Ruby-GNOME2.
+  Copyright (c) 2004-2020 Ruby-GNOME Project Team
+  This program is licenced under the same licence as Ruby-GNOME.
 
   $Id: format.rb,v 1.4 2006/06/17 14:38:08 mutoh Exp $
 =end
 
-require 'gtk2'
-
-if str = Gtk.check_version(2, 2, 0)
-  puts "This sample requires GTK+ 2.2.0 or later"
-  puts str
-  exit
-end
+require 'gtk3'
 
 filename = ARGV[0]
 unless filename
@@ -23,15 +17,11 @@ unless filename
 end
 
 puts fileinfo = GdkPixbuf::Pixbuf.get_file_info(filename)[0]
-puts "name = #{fileinfo.name}"
+puts "name        = #{fileinfo.name}"
 puts "description = #{fileinfo.description}"
-puts "mime_types = #{fileinfo.mime_types.inspect}"
-puts "extensions = #{fileinfo.extensions.inspect}"
-puts "writable = #{fileinfo.writable?}"
-
-if Gtk.check_version?(2, 6, 0)
-  puts "Since 2.6 --- "
-  puts "scalable = #{fileinfo.scalable?}"
-  puts "disabled = #{fileinfo.disabled?}"
-  puts "license = #{fileinfo.license.inspect}"
-end
+puts "mime_types  = #{fileinfo.mime_types.inspect}"
+puts "extensions  = #{fileinfo.extensions.inspect}"
+puts "writable    = #{fileinfo.writable?}"
+puts "scalable    = #{fileinfo.scalable?}"
+puts "disabled    = #{fileinfo.disabled?}"
+puts "license     = #{fileinfo.license.inspect}"


### PR DESCRIPTION
* Update copyright year
* Use gtk3 instead of gtk2
* Skip gtk version checking
* Align Columns