### PR TITLE
gdk_pixbuf2: fix rotate example

### DIFF
--- a/gdk_pixbuf2/sample/rotate.rb
+++ b/gdk_pixbuf2/sample/rotate.rb
@@ -2,14 +2,13 @@
 =begin
   rotate.rb - Ruby/GdkPixbuf sample script.
 
-  Copyright (c) 2005-2016 Ruby-GNOME2 Project Team
-  This program is licenced under the same licence as Ruby-GNOME2.
+  Copyright (c) 2005-2020 Ruby-GNOME Project Team
+  This program is licenced under the same licence as Ruby-GNOME.
 
   $Id: rotate.rb,v 1.3 2006/06/17 14:38:08 mutoh Exp $
 =end
 
-require 'gtk2'
-
+require 'gtk3'
 
 filename = ARGV[0]
 unless filename
@@ -17,22 +16,16 @@ unless filename
   exit(1)
 end
 
-if str = Gtk.check_version(2, 6, 0)
-  puts "This sample requires GTK+ 2.6.0 or later"
-  puts str
-  exit
-end
+vbox = Gtk::Box.new(:vertical)
 
-vbox = Gtk::VBox.new
-
-src =  GdkPixbuf::Pixbuf.new(:file => filename)
-vbox.add(Gtk::Image.new(src))
+src =  GdkPixbuf::Pixbuf.new(file: filename)
+vbox.add(Gtk::Image.new(pixbuf: src))
 
 dst = src.rotate(:counterclockwise)
-vbox.add(Gtk::Image.new(dst))
+vbox.add(Gtk::Image.new(pixbuf: dst))
 
 dst2 = src.rotate(:upsidedown)
-vbox.add(Gtk::Image.new(dst2))
+vbox.add(Gtk::Image.new(pixbuf: dst2))
 
 window = Gtk::Window.new
 window.signal_connect('delete-event') do
@@ -42,4 +35,3 @@ end
 window.add(vbox).show_all
 
 Gtk.main
-


### PR DESCRIPTION
* Update copyright year
* Use gtk3 instead of gtk2
* VBox -> Box.new(:vertical)
* Skip gtk version checking
* Fix Image#new arguments
