### PR TITLE
gdk_pixbuf2: fix save example

### DIFF
--- a/gdk_pixbuf2/sample/save.rb
+++ b/gdk_pixbuf2/sample/save.rb
@@ -2,8 +2,8 @@
 =begin
   save.rb - Ruby/GdkPixbuf sample script.
 
-  Copyright (c) 2002-2016 Ruby-GNOME2 Project Team
-  This program is licenced under the same licence as Ruby-GNOME2.
+  Copyright (c) 2002-2020 Ruby-GNOME Project Team
+  This program is licenced under the same licence as Ruby-GNOME.
 
   $Id: save.rb,v 1.5 2006/06/17 14:38:08 mutoh Exp $
 =end
@@ -17,7 +17,7 @@ if ! from or ! to
   exit(1)
 end
 
-src =  GdkPixbuf::Pixbuf.new(from)
+src = GdkPixbuf::Pixbuf.new(:file => from)
 
 dst = src.scale(300, 300, :hyper)
 # This doesn't work ....


### PR DESCRIPTION
* Update copyright year
* Fix Pixbuf#new arguments
* Remove a needless space