### PR TITLE
gdk_pixbuf2: fix scale example

### DIFF
--- a/gdk_pixbuf2/sample/scale.rb
+++ b/gdk_pixbuf2/sample/scale.rb
@@ -2,13 +2,13 @@
 =begin
   scale.rb - Ruby/GdkPixbuf sample script.
 
-  Copyright (c) 2002-2016 Ruby-GNOME2 Project Team
-  This program is licenced under the same licence as Ruby-GNOME2.
+  Copyright (c) 2002-2020 Ruby-GNOME Project Team
+  This program is licenced under the same licence as Ruby-GNOME.
 
   $Id: scale.rb,v 1.10 2006/06/17 14:38:08 mutoh Exp $
 =end
 
-require 'gtk2'
+require 'gtk3'
 
 filename = ARGV[0]
 unless filename
@@ -16,14 +16,14 @@ unless filename
   exit(1)
 end
 
-vbox = Gtk::VBox.new
+vbox = Gtk::Box.new(:vertical)
 
 src =  GdkPixbuf::Pixbuf.new(:file => filename)
-vbox.add(Gtk::Image.new(src))
+vbox.add(Gtk::Image.new(:pixbuf => src))
 
 dst = src.scale(200, 200, :nearest)
 dst.scale!(src, 60, 60, 90, 90, -50, 50, 6, 3)
-vbox.add(Gtk::Image.new(dst))
+vbox.add(Gtk::Image.new(:pixbuf => dst))
 
 dst2 = GdkPixbuf::Pixbuf.new(:colorspace => :rgb,
                              :has_alpha =>true,
@@ -32,7 +32,7 @@ dst2 = GdkPixbuf::Pixbuf.new(:colorspace => :rgb,
                              :height => 200)
 dst2.scale!(src, 0, 0, 100, 100, 0, 0, 1.5, 1.5)
 
-vbox.add(Gtk::Image.new(dst2))
+vbox.add(Gtk::Image.new(:pixbuf => dst2))
 
 dst3 = GdkPixbuf::Pixbuf.new(:colorspace => :rgb,
                              :has_alpha =>true,
@@ -40,7 +40,7 @@ dst3 = GdkPixbuf::Pixbuf.new(:colorspace => :rgb,
                              :width => 200,
                              :height => 200)
 dst3.scale!(src, 0, 0, 200, 200, 0, 0, 5, 3, :hyper)
-vbox.add(Gtk::Image.new(dst3))
+vbox.add(Gtk::Image.new(:pixbuf => dst3))
 
 window = Gtk::Window.new
 window.signal_connect('delete-event') do


### PR DESCRIPTION
* Update copyright year
* Use gtk3 instead of gtk2
* VBox -> Box.new(:vertical)
* Fix Gtk::Image#new argument