### PR TITLE
Fix Ruby-Gnome2 -> Ruby-Gnome

### DIFF
--- a/goffice/dependency-check/Rakefile
+++ b/goffice/dependency-check/Rakefile
@@ -14,22 +14,6 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-# Copyright (C) 2017  Ruby-GNOME2 Project Team
-#
-# This library is free software; you can redistribute it and/or
-# modify it under the terms of the GNU Lesser General Public
-# License as published by the Free Software Foundation; either
-# version 2.1 of the License, or (at your option) any later version.
-#
-# This library is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public
-# License along with this library; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-
 require "pkg-config"
 require "native-package-installer"
 

--- a/gtk3/sample/misc/cairo-cursor.rb
+++ b/gtk3/sample/misc/cairo-cursor.rb
@@ -2,7 +2,7 @@
   cairo_cursor.rb Ruby/GTK3 script
   Adapted from https://developer.gnome.org/gtk3/stable/ch25s02.html#id-1.6.3.4.5
   Copyright (c) 2015-2020 Ruby-GNOME Project Team
-  This program is licenced under the same licence as Ruby-GNOME2.
+  This program is licenced under the same licence as Ruby-GNOME.
 =end
 
 require "gtk3"

--- a/gtk3/sample/misc/calendar.rb
+++ b/gtk3/sample/misc/calendar.rb
@@ -2,7 +2,7 @@
   calendar.rb - Gtk::Calendar sample script.
 
   Copyright (c) 2002-2020 Ruby-GNOME Project Team
-  This program is licenced under the same licence as Ruby-GNOME2.
+  This program is licenced under the same licence as Ruby-GNOME.
 =end
 
 require "gtk3"


### PR DESCRIPTION
Fix Ruby-gnome2 -> Ruby-Gnome

I searched for files that used both Ruby-Gnome and Ruby-Gnome2.

```
grep "Ruby-GNOME " -rl | xargs grep "Ruby-GNOME2" -rl
```

And found 4 files. 

* gtk3/sample/misc/cairo-cursor.rb  :confused:
* gtk3/sample/misc/calendar.rb  :confused:
* goffice/dependency-check/Rakefile :new:
* glib2/ext/glib2/rbglib.c (No need to fix)

Fixed.