### PR TITLE
gdk_pixbuf2: fix utils example

### DIFF
--- a/gdk_pixbuf2/sample/utils.rb
+++ b/gdk_pixbuf2/sample/utils.rb
@@ -2,13 +2,13 @@
 =begin
   utils.rb - Ruby/GdkPixbuf sample script.
 
-  Copyright (c) 2002-2016 Ruby-GNOME2 Project Team
-  This program is licenced under the same licence as Ruby-GNOME2.
+  Copyright (c) 2002-2020 Ruby-GNOME Project Team
+  This program is licenced under the same licence as Ruby-GNOME.
 
   $Id: utils.rb,v 1.4 2006/06/17 14:38:08 mutoh Exp $
 =end
 
-require 'gtk2'
+require 'gtk3'
 
 filename = ARGV[0]
 unless filename
@@ -18,7 +18,7 @@ end
 
 src =  GdkPixbuf::Pixbuf.new(:file => filename)
 
-vbox = Gtk::VBox.new
+vbox = Gtk::Box.new(:vertical)
 
 dst = src.add_alpha(true, 0, 0, 0)
 vbox.pack_start(Gtk::Image.new(dst))
@@ -28,14 +28,15 @@ dst = GdkPixbuf::Pixbuf.new(:colorspace => :rgb,
                             :bits_per_sample => 8, 
                             :width => src.width + 20,
                             :height => src.height + 30)
+dst.fill!(0xff000099) # Clears a pixbuf to the given RGBA value
 src.copy_area(0, 0, src.width / 2, src.height / 2, dst, 10, 20)
-vbox.pack_start(Gtk::Image.new(dst))
+vbox.pack_start(Gtk::Image.new(:pixbuf => dst))
 
 dst = src.saturate_and_pixelate(0.3, true)
-vbox.pack_start(Gtk::Image.new(dst))
+vbox.pack_start(Gtk::Image.new(:pixbuf => dst))
 
-dst = src.fill!(0xff000099) #RGBA
-vbox.pack_start(Gtk::Image.new(dst))
+dst = src.fill!(0xff000099)
+vbox.pack_start(Gtk::Image.new(:pixbuf => dst))
 
 w = Gtk::Window.new.add(vbox)
 w.signal_connect('delete-event') do


### PR DESCRIPTION
* Update copyright year
* Use gtk3 instead of gtk2
* VBox -> Box.new(:vertical)
* Clears the pixbuf and fill the color
    * before
        ![image](https://user-images.githubusercontent.com/5798442/74599596-04a7ab80-50c8-11ea-8a9a-d7ab2a9c053c.png)


    * after
        ![image](https://user-images.githubusercontent.com/5798442/74599571-bf837980-50c7-11ea-8afc-bfff785b7e46.png)
* Fix Image#new arguments