### PR TITLE
cairo-gobject: ruby_gnome2_base -> ruby_gnome_base

### DIFF
--- a/cairo-gobject/test/run-test.rb
+++ b/cairo-gobject/test/run-test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 #
-# Copyright (C) 2013-2015  Ruby-GNOME2 Project Team
+# Copyright (C) 2013-2020  Ruby-GNOME Project Team
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -16,12 +16,12 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-ruby_gnome2_base = File.join(File.dirname(__FILE__), "..", "..")
-ruby_gnome2_base = File.expand_path(ruby_gnome2_base)
+ruby_gnome_base = File.join(File.dirname(__FILE__), "..", "..")
+ruby_gnome_base = File.expand_path(ruby_gnome_base)
 
-glib_base = File.join(ruby_gnome2_base, "glib2")
-gobject_introspection_base = File.join(ruby_gnome2_base, "gobject-introspection")
-cairo_gobject_base = File.join(ruby_gnome2_base, "cairo-gobject")
+glib_base = File.join(ruby_gnome_base, "glib2")
+gobject_introspection_base = File.join(ruby_gnome_base, "gobject-introspection")
+cairo_gobject_base = File.join(ruby_gnome_base, "cairo-gobject")
 
 modules = [
   [glib_base, "glib2"],


### PR DESCRIPTION
* ~~Update copyright year in README~~
* Change `ruby_gnome2_base` to `ruby_gnome_base`

#1359

```
ruby test/run-test.rb 
```

```
Loaded suite test
Started
..........................
Finished in 0.02428763 seconds.
---------------------------------------------------------
26 tests, 26 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
---------------------------------------------------------
1070.50 tests/s, 1070.50 assertions/s
```