### PR TITLE
clutter: ruby_gnome2_base -> ruby_gnome_base

### DIFF
--- a/clutter/test/run-test.rb
+++ b/clutter/test/run-test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 #
-# Copyright (C) 2012-2015  Ruby-GNOME2 Project Team
+# Copyright (C) 2012-2020  Ruby-GNOME Project Team
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -16,14 +16,14 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-ruby_gnome2_base = File.join(File.dirname(__FILE__), "..", "..")
-ruby_gnome2_base = File.expand_path(ruby_gnome2_base)
+ruby_gnome_base = File.join(File.dirname(__FILE__), "..", "..")
+ruby_gnome_base = File.expand_path(ruby_gnome_base)
 
-glib_base = File.join(ruby_gnome2_base, "glib2")
-cairo_gobject_base = File.join(ruby_gnome2_base, "cairo-gobject")
-gobject_introspection_base = File.join(ruby_gnome2_base, "gobject-introspection")
-pango_base = File.join(ruby_gnome2_base, "pango")
-clutter_base = File.join(ruby_gnome2_base, "clutter")
+glib_base = File.join(ruby_gnome_base, "glib2")
+cairo_gobject_base = File.join(ruby_gnome_base, "cairo-gobject")
+gobject_introspection_base = File.join(ruby_gnome_base, "gobject-introspection")
+pango_base = File.join(ruby_gnome_base, "pango")
+clutter_base = File.join(ruby_gnome_base, "clutter")
 
 modules = [
   [glib_base, "glib2"],


### PR DESCRIPTION
* ~~Update copyright year in README~~
* Change `ruby_gnome2_base` to `ruby_gnome_base`

#1359

```
ruby-gnome/clutter$ ruby test/run-test.rb 
```

```
Loaded suite test
Started
................................................................................
........
Finished in 0.01592881 seconds.
--------------------------------------------------------------------------------
88 tests, 92 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------
5524.58 tests/s, 5775.70 assertions/s
```