### PR TITLE
clutter-gstreamer: ruby_gnome2_base -> ruby_gnome_base

### DIFF
--- a/clutter-gstreamer/test/run-test.rb
+++ b/clutter-gstreamer/test/run-test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 #
-# Copyright (C) 2013-2015  Ruby-GNOME2 Project Team
+# Copyright (C) 2013-2020  Ruby-GNOME Project Team
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -18,17 +18,17 @@
 
 have_make = system("which make > /dev/null")
 
-ruby_gnome2_base = File.join(File.dirname(__FILE__), "..", "..")
-ruby_gnome2_base = File.expand_path(ruby_gnome2_base)
+ruby_gnome_base = File.join(File.dirname(__FILE__), "..", "..")
+ruby_gnome_base = File.expand_path(ruby_gnome_base)
 
-glib_base = File.join(ruby_gnome2_base, "glib2")
-cairo_gobject_base = File.join(ruby_gnome2_base, "cairo-gobject")
-gobject_introspection_base = File.join(ruby_gnome2_base, "gobject-introspection")
-pango_base = File.join(ruby_gnome2_base, "pango")
-gdk_pixbuf2_base = File.join(ruby_gnome2_base, "gdk_pixbuf2")
-clutter_base = File.join(ruby_gnome2_base, "clutter")
-gstreamer_base = File.join(ruby_gnome2_base, "gstreamer")
-clutter_gstreamer_base = File.join(ruby_gnome2_base, "clutter-gstreamer")
+glib_base = File.join(ruby_gnome_base, "glib2")
+cairo_gobject_base = File.join(ruby_gnome_base, "cairo-gobject")
+gobject_introspection_base = File.join(ruby_gnome_base, "gobject-introspection")
+pango_base = File.join(ruby_gnome_base, "pango")
+gdk_pixbuf2_base = File.join(ruby_gnome_base, "gdk_pixbuf2")
+clutter_base = File.join(ruby_gnome_base, "clutter")
+gstreamer_base = File.join(ruby_gnome_base, "gstreamer")
+clutter_gstreamer_base = File.join(ruby_gnome_base, "clutter-gstreamer")
 
 modules = [
   [glib_base, "glib2"],


### PR DESCRIPTION
* Change `ruby_gnome2_base` to `ruby_gnome_base`

```
clutter-gstreamer$ ruby test/run-test.rb 
```

```
Loaded suite test
Started
.O
================================================================================
/home/kojix2/Ruby/ruby-gnome/clutter-gstreamer/test/clutter-gstreamer-test-utils.rb:30:in `only_older_clutter_gstreamer_version'
Omission: Require Clutter-GStreamer < 3.0.0 [test_texture(ClutterGstVideoSinkTest)]
================================================================================
....
Finished in 0.113136679 seconds.
--------------------------------------------------------------------------------
6 tests, 5 assertions, 0 failures, 0 errors, 0 pendings, 1 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------
53.03 tests/s, 44.19 assertions/s
```