### PR TITLE
gdk4: ruby_gnome2_base -> ruby_gnome_base

### DIFF
--- a/gdk4/test/run-test.rb
+++ b/gdk4/test/run-test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 #
-# Copyright (C) 2013-2018  Ruby-GNOME2 Project Team
+# Copyright (C) 2013-2020  Ruby-GNOME Project Team
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -16,17 +16,17 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-ruby_gnome2_base = File.join(File.dirname(__FILE__), "..", "..")
-ruby_gnome2_base = File.expand_path(ruby_gnome2_base)
+ruby_gnome_base = File.join(File.dirname(__FILE__), "..", "..")
+ruby_gnome_base = File.expand_path(ruby_gnome_base)
 
-glib_base = File.join(ruby_gnome2_base, "glib2")
-gio2_base = File.join(ruby_gnome2_base, "gio2")
-atk_base = File.join(ruby_gnome2_base, "atk")
-cairo_gobject_base = File.join(ruby_gnome2_base, "cairo-gobject")
-pango_base = File.join(ruby_gnome2_base, "pango")
-gdk_pixbuf_base = File.join(ruby_gnome2_base, "gdk_pixbuf2")
-gobject_introspection_base = File.join(ruby_gnome2_base, "gobject-introspection")
-gdk4_base = File.join(ruby_gnome2_base, "gdk4")
+glib_base = File.join(ruby_gnome_base, "glib2")
+gio2_base = File.join(ruby_gnome_base, "gio2")
+atk_base = File.join(ruby_gnome_base, "atk")
+cairo_gobject_base = File.join(ruby_gnome_base, "cairo-gobject")
+pango_base = File.join(ruby_gnome_base, "pango")
+gdk_pixbuf_base = File.join(ruby_gnome_base, "gdk_pixbuf2")
+gobject_introspection_base = File.join(ruby_gnome_base, "gobject-introspection")
+gdk4_base = File.join(ruby_gnome_base, "gdk4")
 
 [
   [glib_base, "glib2"],


### PR DESCRIPTION
* Change `ruby_gnome2_base` to `ruby_gnome_base`

NOTE: I haven't installed and tried gdk4 yet. This pull request is intended to make the same changes as other Ruby-Gnome packages. Thanks.