### PR TITLE
gnumeric: ruby_gnome2_base -> ruby_gnome_base

### DIFF
--- a/gnumeric/test/run-test.rb
+++ b/gnumeric/test/run-test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 #
-# Copyright (C) 2016-2017  Ruby-GNOME2 Project Team
+# Copyright (C) 2016-2020  Ruby-GNOME Project Team
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -16,21 +16,21 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-ruby_gnome2_base = File.join(File.dirname(__FILE__), "..", "..")
-ruby_gnome2_base = File.expand_path(ruby_gnome2_base)
+ruby_gnome_base = File.join(File.dirname(__FILE__), "..", "..")
+ruby_gnome_base = File.expand_path(ruby_gnome_base)
 
-glib_base = File.join(ruby_gnome2_base, "glib2")
-atk_base = File.join(ruby_gnome2_base, "atk")
-pango_base = File.join(ruby_gnome2_base, "pango")
-gdk_pixbuf_base = File.join(ruby_gnome2_base, "gdk_pixbuf2")
-cairo_gobject_base = File.join(ruby_gnome2_base, "cairo-gobject")
-gobject_introspection_base = File.join(ruby_gnome2_base, "gobject-introspection")
-gio2_base = File.join(ruby_gnome2_base, "gio2")
-gdk3_base = File.join(ruby_gnome2_base, "gdk3")
-gtk3_base = File.join(ruby_gnome2_base, "gtk3")
-gsf_base = File.join(ruby_gnome2_base, "gsf")
-goffice_base = File.join(ruby_gnome2_base, "goffice")
-gnumeric_base = File.join(ruby_gnome2_base, "gnumeric")
+glib_base = File.join(ruby_gnome_base, "glib2")
+atk_base = File.join(ruby_gnome_base, "atk")
+pango_base = File.join(ruby_gnome_base, "pango")
+gdk_pixbuf_base = File.join(ruby_gnome_base, "gdk_pixbuf2")
+cairo_gobject_base = File.join(ruby_gnome_base, "cairo-gobject")
+gobject_introspection_base = File.join(ruby_gnome_base, "gobject-introspection")
+gio2_base = File.join(ruby_gnome_base, "gio2")
+gdk3_base = File.join(ruby_gnome_base, "gdk3")
+gtk3_base = File.join(ruby_gnome_base, "gtk3")
+gsf_base = File.join(ruby_gnome_base, "gsf")
+goffice_base = File.join(ruby_gnome_base, "goffice")
+gnumeric_base = File.join(ruby_gnome_base, "gnumeric")
 
 modules = [
   [glib_base, "glib2"],


### PR DESCRIPTION
* Change `ruby_gnome2_base` to `ruby_gnome_base`

```
gnumeric$ ruby test/run-test.rb
```

```
GLib-GObject-CRITICAL **: Object class GOFontSel doesn't implement property 'level' from interface 'GtkFontChooser'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/loader.rb:216:in `load_object_info'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/loader.rb:68:in `load_info'
	from /home/kojix2/Ruby/ruby-gnome/goffice/lib/goffice/loader.rb:62:in `load_info'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/loader.rb:43:in `block in load'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/repository.rb:34:in `block (2 levels) in each'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/repository.rb:33:in `times'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/repository.rb:33:in `block in each'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/repository.rb:32:in `each'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/repository.rb:32:in `each'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/loader.rb:42:in `load'
	from /home/kojix2/Ruby/ruby-gnome/goffice/lib/goffice.rb:46:in `init'
	from /home/kojix2/Ruby/ruby-gnome/gnumeric/lib/gnm.rb:43:in `init'
	from test/run-test.rb:64:in `<main>'
GLib-GObject-CRITICAL **: Object class GOFontSel doesn't implement property 'language' from interface 'GtkFontChooser'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/loader.rb:216:in `load_object_info'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/loader.rb:68:in `load_info'
	from /home/kojix2/Ruby/ruby-gnome/goffice/lib/goffice/loader.rb:62:in `load_info'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/loader.rb:43:in `block in load'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/repository.rb:34:in `block (2 levels) in each'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/repository.rb:33:in `times'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/repository.rb:33:in `block in each'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/repository.rb:32:in `each'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/repository.rb:32:in `each'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/loader.rb:42:in `load'
	from /home/kojix2/Ruby/ruby-gnome/goffice/lib/goffice.rb:46:in `init'
	from /home/kojix2/Ruby/ruby-gnome/gnumeric/lib/gnm.rb:43:in `init'
	from test/run-test.rb:64:in `<main>'
GLib-GObject-CRITICAL **: Object class GOFontSel doesn't implement property 'font-features' from interface 'GtkFontChooser'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/loader.rb:216:in `load_object_info'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/loader.rb:68:in `load_info'
	from /home/kojix2/Ruby/ruby-gnome/goffice/lib/goffice/loader.rb:62:in `load_info'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/loader.rb:43:in `block in load'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/repository.rb:34:in `block (2 levels) in each'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/repository.rb:33:in `times'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/repository.rb:33:in `block in each'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/repository.rb:32:in `each'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/repository.rb:32:in `each'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/loader.rb:42:in `load'
	from /home/kojix2/Ruby/ruby-gnome/goffice/lib/goffice.rb:46:in `init'
	from /home/kojix2/Ruby/ruby-gnome/gnumeric/lib/gnm.rb:43:in `init'
	from test/run-test.rb:64:in `<main>'
GLib-GObject-CRITICAL **: Object class GOFontSelDialog doesn't implement property 'level' from interface 'GtkFontChooser'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/loader.rb:216:in `load_object_info'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/loader.rb:68:in `load_info'
	from /home/kojix2/Ruby/ruby-gnome/goffice/lib/goffice/loader.rb:62:in `load_info'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/loader.rb:43:in `block in load'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/repository.rb:34:in `block (2 levels) in each'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/repository.rb:33:in `times'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/repository.rb:33:in `block in each'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/repository.rb:32:in `each'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/repository.rb:32:in `each'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/loader.rb:42:in `load'
	from /home/kojix2/Ruby/ruby-gnome/goffice/lib/goffice.rb:46:in `init'
	from /home/kojix2/Ruby/ruby-gnome/gnumeric/lib/gnm.rb:43:in `init'
	from test/run-test.rb:64:in `<main>'
GLib-GObject-CRITICAL **: Object class GOFontSelDialog doesn't implement property 'language' from interface 'GtkFontChooser'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/loader.rb:216:in `load_object_info'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/loader.rb:68:in `load_info'
	from /home/kojix2/Ruby/ruby-gnome/goffice/lib/goffice/loader.rb:62:in `load_info'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/loader.rb:43:in `block in load'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/repository.rb:34:in `block (2 levels) in each'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/repository.rb:33:in `times'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/repository.rb:33:in `block in each'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/repository.rb:32:in `each'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/repository.rb:32:in `each'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/loader.rb:42:in `load'
	from /home/kojix2/Ruby/ruby-gnome/goffice/lib/goffice.rb:46:in `init'
	from /home/kojix2/Ruby/ruby-gnome/gnumeric/lib/gnm.rb:43:in `init'
	from test/run-test.rb:64:in `<main>'
GLib-GObject-CRITICAL **: Object class GOFontSelDialog doesn't implement property 'font-features' from interface 'GtkFontChooser'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/loader.rb:216:in `load_object_info'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/loader.rb:68:in `load_info'
	from /home/kojix2/Ruby/ruby-gnome/goffice/lib/goffice/loader.rb:62:in `load_info'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/loader.rb:43:in `block in load'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/repository.rb:34:in `block (2 levels) in each'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/repository.rb:33:in `times'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/repository.rb:33:in `block in each'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/repository.rb:32:in `each'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/repository.rb:32:in `each'
	from /home/kojix2/Ruby/ruby-gnome/gobject-introspection/lib/gobject-introspection/loader.rb:42:in `load'
	from /home/kojix2/Ruby/ruby-gnome/goffice/lib/goffice.rb:46:in `init'
	from /home/kojix2/Ruby/ruby-gnome/gnumeric/lib/gnm.rb:43:in `init'
	from test/run-test.rb:64:in `<main>'
Loaded suite test
Started
O
====================================================================================================================================================================================
/home/kojix2/Ruby/ruby-gnome/gnumeric/test/test-convert.rb:27:in `block in <class:ConvertTest>'
Omission: opener can be nil but .gir file doesn't mark as nullable [test: .gnumeric -> .csv(ConvertTest)]
====================================================================================================================================================================================

Finished in 0.019330987 seconds.
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1 tests, 0 assertions, 0 failures, 0 errors, 0 pendings, 1 omissions, 0 notifications
0% passed
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
51.73 tests/s, 0.00 assertions/s
```