### PR TITLE
gtk3: ruby_gnome2_base -> ruby_gnome_base

### DIFF
--- a/gtk3/test/run-test.rb
+++ b/gtk3/test/run-test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 #
-# Copyright (C) 2013-2017  Ruby-GNOME2 Project Team
+# Copyright (C) 2013-2020  Ruby-GNOME Project Team
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -16,18 +16,18 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-ruby_gnome2_base = File.join(File.dirname(__FILE__), "..", "..")
-ruby_gnome2_base = File.expand_path(ruby_gnome2_base)
+ruby_gnome_base = File.join(File.dirname(__FILE__), "..", "..")
+ruby_gnome_base = File.expand_path(ruby_gnome_base)
 
-glib_base = File.join(ruby_gnome2_base, "glib2")
-gobject_introspection_base = File.join(ruby_gnome2_base, "gobject-introspection")
-atk_base = File.join(ruby_gnome2_base, "atk")
-cairo_gobject_base = File.join(ruby_gnome2_base, "cairo-gobject")
-pango_base = File.join(ruby_gnome2_base, "pango")
-gdk_pixbuf_base = File.join(ruby_gnome2_base, "gdk_pixbuf2")
-gio2_base = File.join(ruby_gnome2_base, "gio2")
-gdk3_base = File.join(ruby_gnome2_base, "gdk3")
-gtk3_base = File.join(ruby_gnome2_base, "gtk3")
+glib_base = File.join(ruby_gnome_base, "glib2")
+gobject_introspection_base = File.join(ruby_gnome_base, "gobject-introspection")
+atk_base = File.join(ruby_gnome_base, "atk")
+cairo_gobject_base = File.join(ruby_gnome_base, "cairo-gobject")
+pango_base = File.join(ruby_gnome_base, "pango")
+gdk_pixbuf_base = File.join(ruby_gnome_base, "gdk_pixbuf2")
+gio2_base = File.join(ruby_gnome_base, "gio2")
+gdk3_base = File.join(ruby_gnome_base, "gdk3")
+gtk3_base = File.join(ruby_gnome_base, "gtk3")
 
 [
   [glib_base, "glib2"],


### PR DESCRIPTION
* Change `ruby_gnome2_base` to `ruby_gnome_base`

```
gtk3$ ruby test/run-test.rb
```

```
Loaded suite test
Started
............................................................................................................................
............................................................................................................................
...........................
(run-test.rb:29578): Gtk-WARNING **: 12:13:55.829: Style property "nonexistent" is not registered
.................................................................................................
........................
(run-test.rb:29578): Gtk-WARNING **: 12:13:56.030: Could not find signal handler 'on_move_cursor'.  Did you compile with -rdynamic?
.
(run-test.rb:29578): Gtk-WARNING **: 12:13:56.032: Could not find signal handler 'on_move_cursor'.  Did you compile with -rdynamic?
........../home/kojix2/Ruby/ruby-gnome/pango/lib/pango/rectangle.rb:50: warning: Object#tainted? is deprecated and will be removed in Ruby 3.2.
...
Finished in 2.57604604 seconds.
----------------------------------------------------------------------------------------------------------------------------
410 tests, 473 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------
159.16 tests/s, 183.61 assertions/s
```