### PR TITLE
libsecret: ruby_gnome2_base -> ruby_gnome_base

### DIFF
--- a/libsecret/test/run-test.rb
+++ b/libsecret/test/run-test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 #
-# Copyright (C) 2019  Ruby-GNOME2 Project Team
+# Copyright (C) 2019-2020  Ruby-GNOME Project Team
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -16,12 +16,12 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-ruby_gnome2_base = File.join(File.dirname(__FILE__), "..", "..")
-ruby_gnome2_base = File.expand_path(ruby_gnome2_base)
+ruby_gnome_base = File.join(File.dirname(__FILE__), "..", "..")
+ruby_gnome_base = File.expand_path(ruby_gnome_base)
 
-glib_base = File.join(ruby_gnome2_base, "glib2")
-gobject_introspection_base = File.join(ruby_gnome2_base, "gobject-introspection")
-libsecret_base = File.join(ruby_gnome2_base, "libsecret")
+glib_base = File.join(ruby_gnome_base, "glib2")
+gobject_introspection_base = File.join(ruby_gnome_base, "gobject-introspection")
+libsecret_base = File.join(ruby_gnome_base, "libsecret")
 
 modules = [
   [glib_base, "glib2"],


### PR DESCRIPTION
* Change `ruby_gnome2_base` to `ruby_gnome_base`

```
libsecret$ ruby test/run-test.rb 
```

```
Omit because libsecret is old
```
Umm :confused: 
It seems that libsecret must be compiled from source. (Ubuntu 19.10)