### PR TITLE
webkit-gtk: ruby_gnome2_base -> ruby_gnome_base

### DIFF
--- a/webkit-gtk/test/run-test.rb
+++ b/webkit-gtk/test/run-test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 #
-# Copyright (C) 2013-2015  Ruby-GNOME2 Project Team
+# Copyright (C) 2013-2020  Ruby-GNOME Project Team
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -16,19 +16,19 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-ruby_gnome2_base = File.join(File.dirname(__FILE__), "..", "..")
-ruby_gnome2_base = File.expand_path(ruby_gnome2_base)
+ruby_gnome_base = File.join(File.dirname(__FILE__), "..", "..")
+ruby_gnome_base = File.expand_path(ruby_gnome_base)
 
-glib_base = File.join(ruby_gnome2_base, "glib2")
-gio_base = File.join(ruby_gnome2_base, "gio2")
-atk_base = File.join(ruby_gnome2_base, "atk")
-pango_base = File.join(ruby_gnome2_base, "pango")
-gdk_pixbuf_base = File.join(ruby_gnome2_base, "gdk_pixbuf2")
-gdk3_base = File.join(ruby_gnome2_base, "gdk3")
-gtk3_base = File.join(ruby_gnome2_base, "gtk3")
-gobject_introspection_base = File.join(ruby_gnome2_base, "gobject-introspection")
-cairo_gobject_base = File.join(ruby_gnome2_base, "cairo-gobject")
-webkit_gtk_base = File.join(ruby_gnome2_base, "webkit-gtk")
+glib_base = File.join(ruby_gnome_base, "glib2")
+gio_base = File.join(ruby_gnome_base, "gio2")
+atk_base = File.join(ruby_gnome_base, "atk")
+pango_base = File.join(ruby_gnome_base, "pango")
+gdk_pixbuf_base = File.join(ruby_gnome_base, "gdk_pixbuf2")
+gdk3_base = File.join(ruby_gnome_base, "gdk3")
+gtk3_base = File.join(ruby_gnome_base, "gtk3")
+gobject_introspection_base = File.join(ruby_gnome_base, "gobject-introspection")
+cairo_gobject_base = File.join(ruby_gnome_base, "cairo-gobject")
+webkit_gtk_base = File.join(ruby_gnome_base, "webkit-gtk")
 
 modules = [
   [glib_base, "glib2"],


### PR DESCRIPTION
* Change `ruby_gnome2_base` to `ruby_gnome_base`

```
installing 'libwebkitgtk-3.0-dev' native package... failed
```

Umm :confused: 
It seems that libwebkitgtk must be compiled from source. (Ubuntu 19.10)