### PR TITLE
webkit2-gtk: ruby_gnome2_base -> ruby_gnome_base

### DIFF
--- a/webkit2-gtk/test/run-test.rb
+++ b/webkit2-gtk/test/run-test.rb
@@ -16,19 +16,19 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-ruby_gnome2_base = File.join(File.dirname(__FILE__), "..", "..")
-ruby_gnome2_base = File.expand_path(ruby_gnome2_base)
+ruby_gnome_base = File.join(File.dirname(__FILE__), "..", "..")
+ruby_gnome_base = File.expand_path(ruby_gnome_base)
 
-glib_base = File.join(ruby_gnome2_base, "glib2")
-gio_base = File.join(ruby_gnome2_base, "gio2")
-atk_base = File.join(ruby_gnome2_base, "atk")
-pango_base = File.join(ruby_gnome2_base, "pango")
-gdk_pixbuf_base = File.join(ruby_gnome2_base, "gdk_pixbuf2")
-gdk3_base = File.join(ruby_gnome2_base, "gdk3")
-gtk3_base = File.join(ruby_gnome2_base, "gtk3")
-gobject_introspection_base = File.join(ruby_gnome2_base, "gobject-introspection")
-cairo_gobject_base = File.join(ruby_gnome2_base, "cairo-gobject")
-webkit2_gtk_base = File.join(ruby_gnome2_base, "webkit2-gtk")
+glib_base = File.join(ruby_gnome_base, "glib2")
+gio_base = File.join(ruby_gnome_base, "gio2")
+atk_base = File.join(ruby_gnome_base, "atk")
+pango_base = File.join(ruby_gnome_base, "pango")
+gdk_pixbuf_base = File.join(ruby_gnome_base, "gdk_pixbuf2")
+gdk3_base = File.join(ruby_gnome_base, "gdk3")
+gtk3_base = File.join(ruby_gnome_base, "gtk3")
+gobject_introspection_base = File.join(ruby_gnome_base, "gobject-introspection")
+cairo_gobject_base = File.join(ruby_gnome_base, "cairo-gobject")
+webkit2_gtk_base = File.join(ruby_gnome_base, "webkit2-gtk")
 
 modules = [
   [glib_base, "glib2"],


### PR DESCRIPTION
* Change `ruby_gnome2_base` to `ruby_gnome_base`

```
webkit2-gtk$ ruby test/run-test.rb 
```

```
Loaded suite test
Started
..[2020-02-23 16:49:53] INFO  WEBrick 1.6.0
[2020-02-23 16:49:53] INFO  ruby 2.7.0 (2019-12-25) [x86_64-linux]
[2020-02-23 16:49:53] INFO  WEBrick::HTTPServer#start: pid=17678 port=38161
127.0.0.1 - - [23/Feb/2020:16:49:53 JST] "GET / HTTP/1.1" 200 5
- -> /
[2020-02-23 16:49:53] INFO  going to shutdown ...
[2020-02-23 16:49:54] INFO  WEBrick::HTTPServer#start done.
.......
Finished in 1.399719818 seconds.
----------------------------------------------------------------------------------------------------------------------------
9 tests, 9 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------
6.43 tests/s, 6.43 assertions/s
```