### PR TITLE
[WIP] gi: interface

### DIFF
--- a/gobject-introspection/ext/gobject-introspection/rb-gi-private.h
+++ b/gobject-introspection/ext/gobject-introspection/rb-gi-private.h
@@ -22,6 +22,7 @@
 
 #include <ruby.h>
 #include <rbgobject.h>
+#include <rbglib2conversions.h>
 #include <glib-enum-types.h>
 
 #include <girffi.h>

--- a/gobject-introspection/ext/gobject-introspection/rb-gi-repository.c
+++ b/gobject-introspection/ext/gobject-introspection/rb-gi-repository.c
@@ -228,7 +228,7 @@ rg_find(int argc, VALUE *argv, VALUE self)
         VALUE rb_gtype;
         GType gtype;
         rb_gtype = argv[0];
-        gtype = NUM2UINT(rb_gtype);
+        gtype = NUM2ULONG(rb_gtype);
         info = g_irepository_find_by_gtype(SELF(self), gtype);
     } else {
         VALUE rb_namespace, rb_name;

--- a/gobject-introspection/ext/gobject-introspection/rb-gobject-introspection.c
+++ b/gobject-introspection/ext/gobject-introspection/rb-gobject-introspection.c
@@ -258,6 +258,30 @@ rb_gi_hook_up_vfunc(G_GNUC_UNUSED VALUE self,
 }
 
 void
+interface_init(gpointer g_iface,
+               gpointer iface_data) {}
+
+void
+rb_gi_add_interface(G_GNUC_UNUSED VALUE self,
+                    VALUE rb_gtype_klass,
+                    VALUE rb_gtype_mod,
+                    VALUE rb_interface_info)
+{
+    GType gtype_klass = 0;
+    GType gtype_mod = 0;
+    GInterfaceInfo *info = NULL;
+
+    gtype_klass = NUM2LONG(rb_gtype_klass);
+    g_assert(G_TYPE_IS_CLASSED(gtype_klass));
+    gtype_mod = NUM2LONG(rb_gtype_mod);
+
+    info = g_new0 (GInterfaceInfo, 1);
+    info->interface_init = interface_init;
+
+    g_type_add_interface_static (gtype_klass, gtype_mod, info);
+}
+
+void
 Init_gobject_introspection(void)
 {
     VALUE RG_TARGET_NAMESPACE;
@@ -290,4 +314,5 @@ Init_gobject_introspection(void)
     rb_gi_callback_init(RG_TARGET_NAMESPACE);
 
     rb_define_module_function(RG_TARGET_NAMESPACE, "hook_up_vfunc", rb_gi_hook_up_vfunc, 3);
+    rb_define_module_function(RG_TARGET_NAMESPACE, "add_interface", rb_gi_add_interface, 3);
 }

--- a/gobject-introspection/ext/gobject-introspection/rb-gobject-introspection.c
+++ b/gobject-introspection/ext/gobject-introspection/rb-gobject-introspection.c
@@ -22,6 +22,15 @@
 
 #define RG_TARGET_NAMESPACE rb_mGObjectIntrospection
 
+typedef struct {
+    ID name;
+    GICallableInfo *callable_info;
+
+    ffi_cif cif;
+    ffi_closure *closure;
+} RBGIVFuncCallbackData;
+
+static ID id_send;
 static gboolean is_debug_mode = FALSE;
 
 gboolean
@@ -30,10 +39,230 @@ rb_gi_is_debug_mode(void)
     return is_debug_mode;
 }
 
+static void
+find_vfunc_info (GIBaseInfo *vfunc_info,
+                 GType implementor_gtype,
+                 gpointer *implementor_vtable_ret,
+                 GIFieldInfo **field_info_ret)
+{
+    GIBaseInfo *ancestor_info = NULL;
+    GIStructInfo *struct_info = NULL;
+    GIFieldInfo *field_info = NULL;
+
+    ancestor_info = g_base_info_get_container(vfunc_info);
+    // ancestor_gtype = g_registered_type_info_get_g_type (
+    //                       (GIRegisteredTypeInfo *) ancestor_info);
+    struct_info = g_object_info_get_class_struct((GIObjectInfo*) ancestor_info);
+    *implementor_vtable_ret = g_type_class_ref(implementor_gtype);
+
+    field_info = g_struct_info_find_field(
+            struct_info, g_base_info_get_name((GIBaseInfo*) vfunc_info));
+
+    if (field_info != NULL) {
+        GITypeInfo *type_info;
+
+        type_info = g_field_info_get_type (field_info);
+        if (g_type_info_get_tag (type_info) == GI_TYPE_TAG_INTERFACE) {
+            *field_info_ret = field_info;
+        } else {
+            g_base_info_unref (field_info);
+        }
+        g_base_info_unref (type_info);
+    }
+
+    g_base_info_unref (struct_info);
+}
+
+static VALUE
+garg2rval(GIArgument *argument, GITypeTag type_tag)
+{
+    switch (type_tag) {
+    case GI_TYPE_TAG_INT32:
+        return INT2FIX(argument->v_int32);
+    default:
+        rb_raise(rb_eTypeError, "garg2rval: not implemented");
+        break;
+    }
+}
+
+static void
+rval2garg(VALUE value, GITypeTag type_tag, GIArgument *argument)
+{
+    switch (type_tag) {
+    case GI_TYPE_TAG_INT32:
+        argument->v_int32 = FIX2INT(value);
+        break;
+    default:
+        rb_raise(rb_eTypeError, "rval2garg: not implemented");
+        break;
+    }
+}
+
+static void
+rval2ffiarg(VALUE value, ffi_arg *arg)
+{
+    switch (TYPE(value)) {
+    case T_NIL:
+        break;
+    case T_FIXNUM:
+    case T_DATA:
+        *arg = FIX2INT(value);
+        break;
+    default:
+        rb_raise(rb_eTypeError, "rval2ffiarg: not implemented");
+        break;
+    }
+}
+
+static void
+ffi_callback(G_GNUC_UNUSED ffi_cif *cif,
+             void *ret,
+             void **raw_args,
+             void *raw_data)
+{
+    GIArgument **args = NULL;
+    RBGIVFuncCallbackData *data = NULL;
+    GObject* receiver = NULL;
+    VALUE rb_receiver = 0;
+    gint n_args = 0, n_in_args = 0, n_out_args = 0;
+    size_t i = 0, j = 0;
+    VALUE *in_values = NULL;
+    VALUE rb_ret;
+    GIArgInfo arg_info;
+    GITypeInfo type_info;
+    GITypeTag type_tag;
+    GIDirection direction;
+    gboolean ret_type_is_void;
+
+    args = (GIArgument **) raw_args;
+    data = (RBGIVFuncCallbackData *) raw_data;
+
+    receiver = G_OBJECT(args[0]->v_pointer);
+    rb_receiver = GOBJ2RVAL(receiver);
+
+    n_args = g_callable_info_get_n_args(data->callable_info);
+    in_values = (VALUE *) malloc(n_args * sizeof(VALUE));
+    in_values[0] = data->name;
+    n_in_args++;
+
+    for (i = 1, j = 1; i < n_args; i++) {
+        g_callable_info_load_arg(data->callable_info, i, &arg_info);
+        g_arg_info_load_type(&arg_info, &type_info);
+        type_tag = g_type_info_get_tag(&type_info);
+        direction = g_arg_info_get_direction(&arg_info);
+
+        if (type_tag == GI_TYPE_TAG_VOID) continue;
+
+        if (direction == GI_DIRECTION_OUT || direction == GI_DIRECTION_INOUT)
+            n_out_args++;
+
+        if (direction == GI_DIRECTION_OUT) continue;
+
+        in_values[j] = garg2rval(args[i], type_tag);
+        j++; n_in_args++;
+    }
+
+    // result = rb_funcall(rb_receiver, id_send, 1, data->name);
+    rb_ret = rb_funcallv(rb_receiver, id_send, n_in_args, in_values);
+
+    g_callable_info_load_return_type(data->callable_info, &type_info);
+    ret_type_is_void = g_type_info_get_tag(&type_info) == GI_TYPE_TAG_VOID;
+
+    if (n_out_args == 0 && ret_type_is_void) {
+        // do nothing
+    } else if (n_out_args == 0) {
+        rval2ffiarg(rb_ret, ret);
+    } else if (n_out_args == 1 && ret_type_is_void) {
+        for (i = 1; i < n_args; i++) {
+            g_callable_info_load_arg(data->callable_info, i, &arg_info);
+            g_arg_info_load_type(&arg_info, &type_info);
+            type_tag = g_type_info_get_tag(&type_info);
+            direction = g_arg_info_get_direction(&arg_info);
+
+            if (type_tag == GI_TYPE_TAG_VOID || direction == GI_DIRECTION_IN)
+                continue;
+
+            rval2garg(rb_ret, type_tag, args[i]);
+            break;
+        }
+    } else {
+        if (TYPE(rb_ret) != T_ARRAY) {
+            rb_raise(rb_eTypeError, "return type should be Array");
+        }
+
+        for (i = 1, j = 0; i < n_args; i++) {
+            g_callable_info_load_arg(data->callable_info, i, &arg_info);
+            g_arg_info_load_type(&arg_info, &type_info);
+            type_tag = g_type_info_get_tag(&type_info);
+            direction = g_arg_info_get_direction(&arg_info);
+
+            if (type_tag == GI_TYPE_TAG_VOID || direction == GI_DIRECTION_IN)
+                continue;
+
+            rval2garg(rb_ary_entry(rb_ret, j), type_tag, args[i]);
+            j++;
+        }
+    }
+
+    free(in_values);
+}
+
+static VALUE
+rb_gi_hook_up_vfunc(G_GNUC_UNUSED VALUE self,
+                    VALUE rb_name,
+                    VALUE rb_vfunc_info,
+                    VALUE rb_gtype)
+{
+    GIVFuncInfo *vfunc_info = NULL;
+    GType gtype = 0;
+    gpointer implementor_vtable = NULL;
+    GIFieldInfo *field_info = NULL;
+
+    vfunc_info = RVAL2GI_BASE_INFO(rb_vfunc_info);
+    gtype = NUM2LONG(rb_gtype);
+    g_assert(G_TYPE_IS_CLASSED(gtype));
+
+    find_vfunc_info(vfunc_info, gtype, &implementor_vtable, &field_info);
+
+    if (field_info != NULL) {
+        GITypeInfo *type_info = NULL;
+        GIBaseInfo *interface_info = NULL;
+        RBGIVFuncCallbackData *data = NULL;
+        gint offset = 0;
+        gpointer *method_ptr = NULL;
+
+        type_info = g_field_info_get_type(field_info);
+
+        interface_info = g_type_info_get_interface(type_info);
+        g_assert(g_base_info_get_type(interface_info) == GI_INFO_TYPE_CALLBACK);
+
+        data = ALLOC(RBGIVFuncCallbackData);
+        data->name = rb_name;
+        data->callable_info = g_base_info_ref(interface_info);
+        data->closure = g_callable_info_prepare_closure(
+                interface_info, &(data->cif), ffi_callback, data);
+
+        if (data->closure) {
+            offset = g_field_info_get_offset(field_info);
+            method_ptr = G_STRUCT_MEMBER_P(implementor_vtable, offset);
+
+            *method_ptr = data->closure;
+        }
+
+        g_base_info_unref (interface_info);
+        g_base_info_unref (type_info);
+        g_base_info_unref (field_info);
+    }
+
+    return Qnil;
+}
+
 void
 Init_gobject_introspection(void)
 {
     VALUE RG_TARGET_NAMESPACE;
+
+    id_send = rb_intern("__send__");
 
     {
         const char *rb_gi_debug_env = getenv("RB_GI_DEBUG");
@@ -59,4 +288,6 @@ Init_gobject_introspection(void)
     rb_gi_loader_init(RG_TARGET_NAMESPACE);
 
     rb_gi_callback_init(RG_TARGET_NAMESPACE);
+
+    rb_define_module_function(RG_TARGET_NAMESPACE, "hook_up_vfunc", rb_gi_hook_up_vfunc, 3);
 }

--- a/gobject-introspection/ext/gobject-introspection/rb-gobject-introspection.c
+++ b/gobject-introspection/ext/gobject-introspection/rb-gobject-introspection.c
@@ -182,7 +182,7 @@ ffi_callback(G_GNUC_UNUSED ffi_cif *cif,
             if (type_tag == GI_TYPE_TAG_VOID || direction == GI_DIRECTION_IN)
                 continue;
 
-            rval2garg(rb_ret, type_tag, args[i]);
+            rval2garg(rb_ret, type_tag, *(GIArgument **) args[i]);
             break;
         }
     } else {
@@ -199,7 +199,7 @@ ffi_callback(G_GNUC_UNUSED ffi_cif *cif,
             if (type_tag == GI_TYPE_TAG_VOID || direction == GI_DIRECTION_IN)
                 continue;
 
-            rval2garg(rb_ary_entry(rb_ret, j), type_tag, args[i]);
+            rval2garg(rb_ary_entry(rb_ret, j), type_tag, *(GIArgument **) args[i]);
             j++;
         }
     }

--- a/gobject-introspection/ext/gobject-introspection/rb-gobject-introspection.c
+++ b/gobject-introspection/ext/gobject-introspection/rb-gobject-introspection.c
@@ -52,7 +52,17 @@ find_vfunc_info (GIBaseInfo *vfunc_info,
     ancestor_info = g_base_info_get_container(vfunc_info);
     // ancestor_gtype = g_registered_type_info_get_g_type (
     //                       (GIRegisteredTypeInfo *) ancestor_info);
-    struct_info = g_object_info_get_class_struct((GIObjectInfo*) ancestor_info);
+    switch (g_base_info_get_type(ancestor_info)) {
+    case GI_INFO_TYPE_OBJECT:
+        struct_info = g_object_info_get_class_struct((GIObjectInfo*) ancestor_info);
+        break;
+    case GI_INFO_TYPE_INTERFACE:
+        struct_info = g_interface_info_get_iface_struct(ancestor_info);
+        break;
+    default:
+        g_assert_not_reached();
+        break;
+    }
     *implementor_vtable_ret = g_type_class_ref(implementor_gtype);
 
     field_info = g_struct_info_find_field(

--- a/gobject-introspection/lib/gobject-introspection.rb
+++ b/gobject-introspection/lib/gobject-introspection.rb
@@ -61,5 +61,7 @@ require "gobject-introspection/type-info"
 require "gobject-introspection/type-tag"
 require "gobject-introspection/union-info"
 
+require "gobject-introspection/glib2-hook-up-vfunc"
+
 require "gobject-introspection/version"
 require "gobject-introspection/loader"

--- a/gobject-introspection/lib/gobject-introspection.rb
+++ b/gobject-introspection/lib/gobject-introspection.rb
@@ -62,6 +62,7 @@ require "gobject-introspection/type-tag"
 require "gobject-introspection/union-info"
 
 require "gobject-introspection/glib2-hook-up-vfunc"
+require "gobject-introspection/interface"
 
 require "gobject-introspection/version"
 require "gobject-introspection/loader"

--- a/gobject-introspection/lib/gobject-introspection/glib2-hook-up-vfunc.rb
+++ b/gobject-introspection/lib/gobject-introspection/glib2-hook-up-vfunc.rb
@@ -10,7 +10,9 @@ module GLib
         repository = GObjectIntrospection::Repository.default
         klass = ancestors.find do |klass|
           klass.respond_to? :gtype or next
-          repository.find(klass.gtype)&.get_vfunc(vfunc_name)
+          info = repository.find(klass.gtype) or next
+          info.respond_to? :get_vfunc or next
+          info.get_vfunc(vfunc_name)
         end or return
         vfunc_info = repository.find(klass.gtype).get_vfunc(vfunc_name)
 

--- a/gobject-introspection/lib/gobject-introspection/glib2-hook-up-vfunc.rb
+++ b/gobject-introspection/lib/gobject-introspection/glib2-hook-up-vfunc.rb
@@ -1,0 +1,23 @@
+module GLib
+  class Instantiatable
+    class << self
+      alias _method_added method_added
+      def method_added(name)
+        _method_added(name)
+
+        name.to_s =~ /^do_/ or return
+        vfunc_name = name.to_s.sub /^do_/, ''
+        repository = GObjectIntrospection::Repository.default
+        klass = ancestors.find do |klass|
+          klass.respond_to? :gtype or next
+          repository.find(klass.gtype)&.get_vfunc(vfunc_name)
+        end or return
+        vfunc_info = repository.find(klass.gtype).get_vfunc(vfunc_name)
+
+        puts "hook up virtual method #{klass.name}##{vfunc_name}" \
+          " to #{self.name}##{name}"
+        GObjectIntrospection.hook_up_vfunc(name, vfunc_info, gtype)
+      end
+    end
+  end
+end

--- a/gobject-introspection/lib/gobject-introspection/interface.rb
+++ b/gobject-introspection/lib/gobject-introspection/interface.rb
@@ -1,0 +1,10 @@
+module GLib
+  module Interface
+    def included(klass)
+      $stderr.puts "#{klass.name} implements interface #{name}"
+      repository = GObjectIntrospection::Repository.default
+      interface_info = repository.find(gtype)
+      GObjectIntrospection.add_interface(klass.gtype, gtype, interface_info)
+    end
+  end
+end


### PR DESCRIPTION
Rubyで定義したGObjectのサブクラスに，GInterfaceを実装する機能です．

WIPです．[テストコード](https://gist.github.com/yuntan/bfe028947ec19dd822c3ae02d49eafb6)でクラッシュします．クラッシュする行は分かっていますが原因が分かっていません．以下がトレースです．

```
-- C level backtrace information -------------------------------------------
/home/yuntan/.rbenv/versions/2.7.0/lib/libruby.so.2.7(rb_vm_bugreport+0x573) [0x7f4b37b2f4c3] vm_dump.c:755
/home/yuntan/.rbenv/versions/2.7.0/lib/libruby.so.2.7(rb_bug_for_fatal_signal+0xe7) [0x7f4b37957557] error.c:658
/home/yuntan/.rbenv/versions/2.7.0/lib/libruby.so.2.7(sigsegv+0x49) [0x7f4b37a8e269] signal.c:946
/usr/lib/libpthread.so.0(__restore_rt+0x0) [0x7f4b3781b960]
/usr/lib/libgobject-2.0.so.0(g_type_check_instance_cast+0x25) [0x7f4b338e7985]
/home/yuntan/.local/src/github.com/ruby-gnome/ruby-gnome/gobject-introspection/ext/gobject-introspection/gobject_introspection.so(ffi_callback+0x3f) [0x7f4b33a4f00f] rb-gobject-introspection.c:150
/usr/lib/libffi.so.7(0x7f4b378628c2) [0x7f4b378628c2]
/usr/lib/libffi.so.7(0x7f4b37862c20) [0x7f4b37862c20]
/usr/lib/libgobject-2.0.so.0(0x7f4b338d40bd) [0x7f4b338d40bd]
/usr/lib/libgobject-2.0.so.0(g_object_newv+0x25d) [0x7f4b338d52bd]
/home/yuntan/.local/src/github.com/ruby-gnome/ruby-gnome/glib2/ext/glib2/glib2.so(rbgobj_gobject_new+0x10c) [0x7f4b33aa3e3c] rbgobj_object.c:397
/home/yuntan/.local/src/github.com/ruby-gnome/ruby-gnome/glib2/ext/glib2/glib2.so(rbgobj_gobject_new) (null):0
/home/yuntan/.local/src/github.com/ruby-gnome/ruby-gnome/glib2/ext/glib2/glib2.so(rg_initialize+0xe1) [0x7f4b33aa3f61] rbgobj_object.c:867
/home/yuntan/.rbenv/versions/2.7.0/lib/libruby.so.2.7(vm_call_cfunc_with_frame+0x4d) [0x7f4b37b081dc] vm_insnhelper.c:2514
```

rb-gobject-introspection.c:150 が問題の行です．テストコードの`include Gio::ListModel`をコメントするとクラッシュしません．

#1386 に依存してます．