### PR TITLE
Removed unused travicCI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-[![Build Status](https://travis-ci.org/ruby-gnome/ruby-gnome.svg?branch=master)](https://travis-ci.org/ruby-gnome/ruby-gnome)
-[![Gem Version](https://badge.fury.io/rb/gtk3.svg)](https://badge.fury.io/rb/gtk3)
 # Ruby-GNOME
+
+[![Gem Version](https://badge.fury.io/rb/gtk3.svg)](https://badge.fury.io/rb/gtk3)
+
 ![Ruby-GNOME Logo](https://avatars1.githubusercontent.com/u/416159?v=3&s=200)
 Ruby bindings for GNOME
-
 
 This is a set of bindings for the GNOME 2.x and 3.x libraries to use
 from Ruby 2.4, 2.5 and 2.6.


### PR DESCRIPTION
* Remove unused TravisCI badges
* Move the badge position to below the title

I considered adding a badge for Github Actions.
There are three separate badges for Linux, Mac, and Windows.
If it were my personal project, I would add the badges. 

But in the case of ruby-gnome, I can't decide if I should add badges. 
If there are too many badges, it doesn't look elegant.

I don't care about the badge itself, 
but seeing a badge that has stopped working is not a good feeling.

Thank you very much.