### PR TITLE
gi: fix a bug that virtual functions of grandparent class can't be implemented

### DIFF
--- a/gobject-introspection/lib/gobject-introspection/loader.rb
+++ b/gobject-introspection/lib/gobject-introspection/loader.rb
@@ -837,7 +837,6 @@ module GObjectIntrospection
         end
         @virtual_function_implementor.implement(implementor_class.gtype,
                                                 name)
-        true
       end
     end
   end

--- a/gobject-introspection/test/test-loader.rb
+++ b/gobject-introspection/test/test-loader.rb
@@ -72,5 +72,19 @@ class TestLoaderInfo < Test::Unit::TestCase
         resettable_converter.resetted
       end
     end
+
+    def test_ancestor
+      immutable_menu_class = Class.new(Gio::Menu) do
+        type_register("ImmutableMenu")
+
+        def virtual_do_is_mutable
+          false
+        end
+      end
+      immutable_menu = immutable_menu_class.new
+      assert do
+        not immutable_menu.mutable?
+      end
+    end
   end
 end


### PR DESCRIPTION
自身の直接のスーパークラスのvfuncは実装できる一方、それより上の祖先クラスが持つvfuncは実装することができませんでした。

これは `VirtualFunctionImplementable#implement_virtual_function` の戻り値が常に真になっていることが原因と見られたため、直前の行の呼び出しが本来返したい結果であると推測して修正しました。