### PR TITLE
Fix pkgconfig id for gdk4

### DIFF
--- a/gdk4/dependency-check/Rakefile
+++ b/gdk4/dependency-check/Rakefile
@@ -29,7 +29,7 @@ end
 namespace :dependency do
   desc "Check dependency"
   task :check do
-    package_id = "gdk-4.0"
+    package_id = "gtk4"
     unless PKGConfig.check_version?(package_id)
       unless NativePackageInstaller.install(:altlinux => "libgtk+4-devel",
                                             :debian => "libgtk-4-dev",


### PR DESCRIPTION
pkgconfig id for gdk4 is the same as gtk4
https://koji.fedoraproject.org/koji/rpminfo?fileStart=350&rpmID=27692196#filelist