### PR TITLE
Updated link to librsvg

### DIFF
--- a/rsvg2/README.md
+++ b/rsvg2/README.md
@@ -1,6 +1,6 @@
 # Ruby/RSVG2
 
-Ruby/RSVG2 is a Ruby binding of [librsvg](https://github.com/GNOME/librsvg) based on GObject-Introspection.
+Ruby/RSVG2 is a Ruby binding of [librsvg](https://gitlab.gnome.org/GNOME/librsvg) based on GObject-Introspection.
 
 ## Requirements
 

--- a/rsvg2/README.md
+++ b/rsvg2/README.md
@@ -1,6 +1,6 @@
 # Ruby/RSVG2
 
-Ruby/RSVG2 is a Ruby binding of [librsvg](https://developer.gnome.org/rsvg/) based on GObject-Introspection.
+Ruby/RSVG2 is a Ruby binding of [librsvg](https://github.com/GNOME/librsvg) based on GObject-Introspection.
 
 ## Requirements
 


### PR DESCRIPTION
### Summary

- Fixed broken link by pointing it to the [GNOME/librsvg repository](https://github.com/GNOME/librsvg)