### PR TITLE
Fix audio-example

### DIFF
--- a/gstreamer/sample/audio-example.rb
+++ b/gstreamer/sample/audio-example.rb
@@ -32,7 +32,7 @@
 require "gst"
 
 bin = Gst::Pipeline.new("pipeline")
-clock = bin.clock
+clock = bin.pipeline_clock
 src = Gst::ElementFactory.make("audiotestsrc", nil)
 raise "need audiotestsrc from gst-plugins-base" if src.nil?
 sink = Gst::ElementFactory.make("autoaudiosink", nil)
@@ -64,5 +64,5 @@ cs2.set(6 * Gst::SECOND,  440.0 / 20000.0)
 clock_id = clock.new_single_shot_id(clock.time + (7 * Gst::SECOND))
 bin.play
 wait_ret, jitter = Gst::Clock.id_wait(clock_id)
-$stderr.puts "Clock::id_wait returned: #{wait_ret}" if wait_ret != Gst::ClockReturn::OK
+warn "Clock::id_wait returned: #{wait_ret}" if wait_ret != Gst::ClockReturn::OK
 bin.stop


### PR DESCRIPTION
* Use [pipeline_clock](https://github.com/GStreamer/gstreamer/blob/2db3ddaa9d8e9e0a1659d7e48623c512dbda691b/subprojects/gstreamer/tests/examples/controller/audio-example.c#L30)

```ruby
bin.clock              # => nil
bin.pipelie_clock      # => Gst::SystemClock
```

* Use warn instead of $stderr.puts
  * If you do not like this change, undo and merge.