### PR TITLE
Documentation tasks for Rakefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.o
 *.so
 *.swp
+*.yardoc
 .emacs.desktop
 .emacs.desktop.lock
 Makefile
@@ -27,6 +28,7 @@ mkmf.log
 */tmp/
 */vendor/
 */pkg/
+*/yard_docs/
 .gdb_history
 /dist/
 /misc/release.rb

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 *.o
 *.so
 *.swp
-*.yardoc
 .emacs.desktop
 .emacs.desktop.lock
 Makefile
@@ -37,5 +36,6 @@ yard_docs
 /Gemfile.lock
 /Gemfile.local
 /build/.vagrant/
+/.yardoc/
 .RUBYLIBDIR*.time
 .RUBYARCHDIR.time

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ mkmf.log
 */tmp/
 */vendor/
 */pkg/
-*/yard_docs/
+yard_docs
 .gdb_history
 /dist/
 /misc/release.rb

--- a/Rakefile
+++ b/Rakefile
@@ -93,7 +93,7 @@ end
 desc "clean all packages, docs"
 task :clean do
   sh("make", "clean") if File.exist?("Makefile")
-  sh("rm", "-rf", "./yard_docs")
+  rm_rf("yard_docs")
 end
 
 desc "more clean all packages"
@@ -128,7 +128,7 @@ namespace :gem do
                                 ygir_gem.full_gem_path)
     args = [ygir_lib, * packages_rb]
     all_args = %w(bundle exec yard doc -o ./yard_docs/gir/ --load).concat(args)
-    sh Shellwords.join(all_args)
+    sh(*all_args)
   end
 
   task :rubydocs do
@@ -138,7 +138,7 @@ namespace :gem do
         File.join(pkg, "ext", pkg, "**/*.h")
       ]}
     all_args = %w(bundle exec yard doc -o ./yard_docs/ruby/).concat(file_globs)
-    sh Shellwords.join(all_args)
+    sh(*all_args)
   end
 
   desc "push all gems"

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,6 @@ require "pathname"
 require "find"
 require "tmpdir"
 require "open-uri"
-require 'shellwords'
 
 task :default => :test
 

--- a/Rakefile
+++ b/Rakefile
@@ -90,9 +90,10 @@ task :build => ["Makefile"] do
   sh("make")
 end
 
-desc "clean all packages"
+desc "clean all packages, docs"
 task :clean do
   sh("make", "clean") if File.exist?("Makefile")
+  sh("rm", "-rf", "./yard_docs")
 end
 
 desc "more clean all packages"
@@ -117,7 +118,6 @@ namespace :gem do
 
   desc "document all gems"
   task docs: [:girdocs, :rubydocs]
-  CLEAN.include("./yard_docs")
 
   task :girdocs do
     packages_rb = packages.map { |pkg|


### PR DESCRIPTION
The changeset in this pull request will add documentation tasks to the Rakefile
- Task `gem:docs` as presented with `rake -T`, using both of the following tasks
- Task `gem:girdocs` for documentation using yard-gobject-introspection
- Task `gem:rubydocs` for other Ruby docs, using yard

Documentation files will be produced in subdirectories under ./yard_docs/
- in `yard_docs/gir/` for docs using yard-gobject-introspection
- in `yard_docs/ruby/` for Ruby docs using yard

`./yard_docs/` will be removed under the `clean` Rakefile task

`.gitignore` is updated for files created by yard

In commentary: 

Perhaps these Rakefile tasks may serve as any utility for local access to the Ruby-GNOME documentation. This would not be integrated with the documentation tasks for GitHub Actions in Ruby-GNOME.

I'm not certain if all of the decisions in this changeset would be ideal for the project. 

For these added tasks, I've used the `yard_docs` path under the project root directory. This path has been used in the GitHub Actions for Ruby-GNOME. 

The Rakefile tasks added in this changeset would output the documentation to individual directories under  `./yard_docs/`, respectively `gir` for the documentation generated with the yard-gobject-introspection extension for yard, and `ruby` for the rest of the documentation generated by yard.

The `gem:rubydocs` task will add `*.h` files to the set of files processed for the documentation. Although at this time, I'm not personally well familiar with any conventions for developing Ruby extensions, it seems yard was able to process these C header files for the documentation.

While it may be a trivial contribution, I wanted to share this patch along to upstream here. Perhaps the added Rakefile tasks may serve as any kind of helpful utility, whether as presented in this changeset or with any adaptation.

**Update:** The second changeset moves the 'clean' task handling for yard_docs into the main  `clean` task, not requiring `rake/clean` and its side effects for the `clean` task (e,g would remove editor backup files in clean). Simply using `rm -rf` for the yard_docs dir in `clean`, no additional files will be removed with this changeset.