### PR TITLE
evaluating local_gemfile using Bundler DSL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,5 +27,5 @@ gem "yard-gobject-introspection", github: "ruby-gnome/yard-gobject-introspection
 
 local_gemfile = File.join(File.dirname(__FILE__), "Gemfile.local")
 if File.exist?(local_gemfile)
-  instance_eval File.read(local_gemfile)
+  self.eval_gemfile(local_gemfile)
 end

--- a/Gemfile
+++ b/Gemfile
@@ -27,5 +27,5 @@ gem "yard-gobject-introspection", github: "ruby-gnome/yard-gobject-introspection
 
 local_gemfile = File.join(File.dirname(__FILE__), "Gemfile.local")
 if File.exist?(local_gemfile)
-  self.eval_gemfile(local_gemfile)
+  eval_gemfile(local_gemfile)
 end


### PR DESCRIPTION
Within the scope of a **Gemfile** evaluated by bundler, the object referenced as `self` may usually be an object of a type **Bundler::Dsl**

Using the `eval_gemfile` method on the **Bundler::Dsl** instance when evaluating an existing `Gemfile.local`, Bundler will then use a **Bundler::Dsl** syntax for the file. This may also ensure that the filename is added to any Gemfile state data for the **Bundler::Dsl** instance

With this patch, a call to the '**gem**' method in a `Gemfile.local` may then be interpreted by bundler as it being a reference to the '**gem**' method on the **Bundler::Dsl** instance. This may differ to how a call to the 'gem' method would be evaluated in ordinary eval.

e.g using `Gemfile.local` to ensure that an interactive Ruby interpreter of any local preference is available under 'bundle exec'

a `Gemfile.local` in excerpt, for IRB:
~~~~
gem 'irb'
~~~~

alternately, for Pry:
~~~~
gem 'pry'
~~~~

Of course, the additional gem or gems would then be installed by `bundle install` and would be available under `bundle exec`.

This change set ensures Bundler uses its syntax for Gemfile.local


**Update**

In the changelog entry for the change set at the origin of the cherry-pick for this patch branch,  it notably used the wrong syntax for the example text, using a hash-like syntax e.g

> `gem: <name>`.

Still visible in the original changeset, this syntax error was corrected in the cherry-picked changeset before this pull request.
