### PR TITLE
Args patch for Vte::Terminal#feed_child

### DIFF
--- a/vte3/lib/vte3/terminal.rb
+++ b/vte3/lib/vte3/terminal.rb
@@ -64,10 +64,5 @@ module Vte
         end
       end
     end
-
-    alias_method :feed_child_raw, :feed_child
-    def feed_child(text)
-      feed_child_raw(text, text.bytesize)
-    end
   end
 end


### PR DESCRIPTION
With Ruby-GNOME using introspection data from GLib 2.70.4, then using the original `Vte::Terminal feed_child` method aliased as `feed_child_raw`, the `feed_child_raw` method was not accepting two args.

When `Vte::Terminal#feed_child_raw` was called with one arg, a string, then it would send the string to the Pty
