### PR TITLE
gio2, gtk3: defining Gio Action support with new rbgobj_register_mark_func handlers

### DIFF
--- a/gio2/ext/gio2/rb-gio2.c
+++ b/gio2/ext/gio2/rb-gio2.c
@@ -50,15 +50,19 @@ rb_gio2_action_proxy_mark(gpointer object)
 static void
 rb_gio2_application_mark(gpointer object)
 {
-    rb_gio2_action_proxy_mark(object);
-    rbgobj_gc_mark_instance(G_APPLICATION(object));
+    GApplication *app = G_APPLICATION(object);
+    rbgobj_gc_mark_instance(app);
+    if (g_application_get_is_registered(app)) {
+        rb_gio2_action_proxy_mark(app);
+    }
 }
 
 static void
 rb_gio2_simple_action_group_mark(gpointer object)
 {
-    rb_gio2_action_proxy_mark(object);
-    rbgobj_gc_mark_instance(G_SIMPLE_ACTION_GROUP(object));
+    GSimpleActionGroup *group = G_SIMPLE_ACTION_GROUP(object);
+    rbgobj_gc_mark_instance(group);
+    rb_gio2_action_proxy_mark(group);
 }
 
 

--- a/gio2/test/test-action-map.rb
+++ b/gio2/test/test-action-map.rb
@@ -48,4 +48,32 @@ class TestActionMap < Test::Unit::TestCase
       assert_equal([action, "X"], args)
     end
   end
+
+  sub_test_case "#add_action / #lookup_action / #remove_action" do
+    def setup
+      super
+      @action_name = "test"
+      @action = Gio::SimpleAction.new(@action_name)
+    end
+
+    test "add action, lookup action" do
+      @map.add_action(@action)
+      out = @map.lookup_action(@action_name)
+      assert_equal(@action, out)
+    end
+
+    test "add action, remove action, lookup action" do
+      @map.add_action(@action)
+      @map.remove_action(@action_name)
+      out = @map.lookup_action(@action_name)
+      assert_nil(out)
+    end
+
+    test "add action, GC, lookup action" do
+      @map.add_action(@action)
+      GC.start
+      out = @map.lookup_action(@action_name)
+      assert_equal(@action, out)
+    end
+  end
 end

--- a/gio2/test/test-application.rb
+++ b/gio2/test/test-application.rb
@@ -1,0 +1,49 @@
+# Copyright (C) 2022 Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+class TestApplication < Test::Unit::TestCase
+  def setup
+    @app = Gio::Application.new("org.example.test", 0)
+  end
+
+  sub_test_case "as Gio::ActionMap" do
+    def setup
+      super
+      @action_name = "test"
+      @action = Gio::SimpleAction.new(@action_name)
+    end
+
+    test "add action, lookup action" do
+      @app.add_action(@action)
+      out = @app.lookup_action(@action_name)
+      assert_equal(@action, out)
+    end
+
+    test "add action, remove action, lookup action" do
+      @app.add_action(@action)
+      @app.remove_action(@action_name)
+      out = @app.lookup_action(@action_name)
+      assert_nil(out)
+    end
+
+    test "add action, GC, lookup action" do
+      @app.add_action(@action)
+      GC.start
+      out = @app.lookup_action(@action_name)
+      assert_equal(@action, out)
+    end
+  end
+end

--- a/gtk3/ext/gtk3/rb-gtk3-widget.c
+++ b/gtk3/ext/gtk3/rb-gtk3-widget.c
@@ -62,6 +62,29 @@ rb_gtk3_widget_draw(RGClosureCallData *data)
                         RVAL2CBOOL(rb_stop_propagate));
 }
 
+
+static void
+rb_gtk3_widget_mark(gpointer object)
+{
+    GtkWidget *widget;
+    GActionGroup *group;
+    const gchar** prefixes;
+    const gchar* prefix;
+    size_t n;
+
+    widget = GTK_WIDGET(object);
+    rbgobj_gc_mark_instance(widget);
+
+    prefixes = gtk_widget_list_action_prefixes(widget);
+    for (n = 0; prefixes[n] != NULL; n++) {
+        prefix = prefixes[n];
+        group = gtk_widget_get_action_group(widget, prefix);
+        if (group != NULL) {
+            rbgobj_gc_mark_instance(group);
+        }
+    }
+}
+
 void
 rbgtk3_widget_init(void)
 {
@@ -72,6 +95,8 @@ rbgtk3_widget_init(void)
     RG_TARGET_NAMESPACE = rb_const_get(mGtk, rb_intern("Widget"));
 
     RG_DEF_PRIVATE_METHOD(initialize_post, 0);
+
+    rbgobj_register_mark_func(GTK_TYPE_WIDGET, rb_gtk3_widget_mark);
 
     rbgobj_set_signal_call_func(RG_TARGET_NAMESPACE,
                                 "draw",

--- a/gtk3/ext/gtk3/rb-gtk3.h
+++ b/gtk3/ext/gtk3/rb-gtk3.h
@@ -21,6 +21,7 @@
 #ifndef RB_GTK3_H
 #define RB_GTK3_H
 
+#include <gio/gio.h>
 #include <gtk/gtk.h>
 
 #include <rb-gobject-introspection.h>

--- a/gtk3/gtk3.gemspec
+++ b/gtk3/gtk3.gemspec
@@ -44,4 +44,5 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency("atk", "= #{s.version}")
   s.add_runtime_dependency("gdk3", "= #{s.version}")
+  s.add_runtime_dependency("gio2", "= #{s.version}")
 end

--- a/gtk3/test/test-gtk-widget.rb
+++ b/gtk3/test/test-gtk-widget.rb
@@ -305,4 +305,36 @@ class TestGtkWidget < Test::Unit::TestCase
       assert_equal(["on_move_cursor"], handler_names)
     end
   end
+
+  sub_test_case "Gio::ActionGroup support" do
+    def setup
+      super
+      @action_group = Gio::SimpleActionGroup.new
+      @action_prefix = "rg"
+    end
+
+    test("#insert_action_group [add]") do
+      @widget.insert_action_group(@action_prefix, @action_group)
+    end
+
+    test("#get_action_group") do
+      @widget.insert_action_group(@action_prefix, @action_group)
+      group_out = @widget.get_action_group(@action_prefix)
+      assert_not_nil(group_out)
+      assert_equal(group_out, @action_group)
+    end
+
+    test("#insert_action_group [remove]") do
+      @widget.insert_action_group(@action_prefix, @action_group)
+      @widget.insert_action_group(@action_prefix, nil)
+      group_out = @widget.get_action_group(@action_prefix)
+      assert_nil(group_out)
+    end
+
+    test("#list_action_prefixes") do
+      @widget.insert_action_group(@action_prefix, @action_group)
+      prefixes = @widget.action_prefixes
+      assert_equal(prefixes, [@action_prefix])
+    end
+  end
 end

--- a/gtk3/test/test-gtk-widget.rb
+++ b/gtk3/test/test-gtk-widget.rb
@@ -313,11 +313,7 @@ class TestGtkWidget < Test::Unit::TestCase
       @action_prefix = "rg"
     end
 
-    test("#insert_action_group [add]") do
-      @widget.insert_action_group(@action_prefix, @action_group)
-    end
-
-    test("#get_action_group") do
+    test("#insert_action_group, #get_action_group") do
       @widget.insert_action_group(@action_prefix, @action_group)
       group_out = @widget.get_action_group(@action_prefix)
       assert_not_nil(group_out)
@@ -333,6 +329,13 @@ class TestGtkWidget < Test::Unit::TestCase
 
     test("#list_action_prefixes") do
       @widget.insert_action_group(@action_prefix, @action_group)
+      prefixes = @widget.action_prefixes
+      assert_equal(prefixes, [@action_prefix])
+    end
+
+    test("#list_action_prefixes [GC]") do
+      @widget.insert_action_group(@action_prefix, @action_group)
+      GC.start
       prefixes = @widget.action_prefixes
       assert_equal(prefixes, [@action_prefix])
     end


### PR DESCRIPTION
For a purpose of a sense of _widget-scoped actions_ in a UI design for an application, I've been using a number of custom **Gio::SimpleActionGroup** to provide custom action prefixes other than `win` or `app`. Each custom action group is bound to some individual widget in the UI. 

This has been approached as so, as in order to call an action's callback function from some **Gtk::Actionable** widget within the effective _widget scope_ of each bound **Gio::SimpleAction**

The implementation of each action in Ruby would correspond, ideally, to any single _Action Name_ entered in the Glade UI design for a **Gtk::Actionable** widget e.g `prefix.name` or `prefix.name::detailed-part`. After coordinating the Glade UI design with the implementation in Ruby, the custom action prefix/name bindings have been working out up to the point of GC. 

After GC, I'd been seeing the following message for actions defined under these custom action prefixes or action groups:

~~~~
Ruby/GLib2-WARNING **: 17:04:48.170: GRClosure invoking callback: already destroyed: GSimpleAction::activate
~~~~

The GTK UI would then present each actionable widget as though each such action was still available, but the widget would not activate the action's `activate` signal callback function after GC. This was not encountered for an action bound under the `app` prefix, e.g the `app.quit` action was still available. It was encountered for actions bound under other prefixes, e.g `editor.popup`

In trying to develop a patch for this, I've found an approach that seems to have mostly worked out. With the patch, that message no longer appears after GC. Moreover, each action group then continues to be available for facilitating the activation of any individual action via the GTK UI.

I'm not certain if more of an illustration could be helpful for explaining the rationale of this methodology. The following patch seems to work. Quoting the changelog description:

rb-gio2.c:
- defining mark functions for Gio::Action objects encapsulated in each Gio::SimpleActionGroup or Gio::Application
- Declaring rbgobj_register_mark_func handlers for Gio::SimpleActionGroup, Gio::Application, and Gio::Action in Init_gio2

rb-gtk3-widget.c:
- Defining a mark function for marking each encapsulated GActionGroup in each Gtk::Widget
- Declaring rb_gtk3_widget_mark as an rbgobj_register_mark_func handler in rbgtk3_widget_init

rb-gtk3.h:
- Adding a reference to the gio header

gtk3.gemspec:
- Adding gio as a dependency

test-gtk-widget.rb
- Adding a test case for Gio::ActionGroup encapsulation in Gtk::Widget

----

**Known limitations to this patch:** 

Given the following in the description for `gtk_widget_get_action_group` and concerning the mark function added to **Gtk::Widget** with this patch, I'm afraid that the Gtk::Widget mark function may mark an action group more than once 

>  "The resulting GActionGroup may have been registered to widget or any GtkWidget in its ancestry." 
[[Gtk.Widget.get_action_group](https://docs.gtk.org/gtk3/method.Widget.get_action_group.html)]

If GTK may not have provided any API for determining if a given action group is bound directly to the provided widget and/or bound directly to some containing widget, then I'm afraid it may be non-trivial to work around this limitation.

Secondly, I'm not certain if or how this could be applied for GTK 4 support. Having developed what seems like a patch that works for GTK 3, I thought it may be helpful to send the patch along for contribution/review.

This patch may at least serve to ensure that each Gio::SimpleActionGroup and each Gio::SimpleAction will be marked before GC, _at least once_.

Under local testing, the patch seems to work out for preventing that any custom action groups and any encapsulated Gio::SimpleAction instances would disappear under GC