### PR TITLE
glib2: print/parse methods for GVariant

### DIFF
--- a/glib2/ext/glib2/rbglib-variant.c
+++ b/glib2/ext/glib2/rbglib-variant.c
@@ -330,6 +330,6 @@ Init_glib_variant(void)
     RG_DEF_METHOD(initialize, -1);
     RG_DEF_METHOD(value, 0);
     RG_DEF_METHOD(type, 0);
-    RG_DEF_METHOD(variant_print, 0);
+    RG_DEF_METHOD(variant_print, 1);
     RG_DEF_SMETHOD(parse, 2);
 }

--- a/glib2/lib/glib2.rb
+++ b/glib2/lib/glib2.rb
@@ -338,6 +338,7 @@ require "glib2/version"
 require "glib2/regex"
 require "glib2/date-time"
 require "glib2/deprecated"
+require "glib2/variant"
 =begin
 Don't we need this?
 ObjectSpace.define_finalizer(GLib) {

--- a/glib2/lib/glib2/variant.rb
+++ b/glib2/lib/glib2/variant.rb
@@ -23,5 +23,11 @@ module GLib
         parse_raw(string, type)
       end
     end
+
+    alias_method :variant_print_raw, :variant_print
+
+    def variant_print(type_annotate = false)
+      variant_print_raw(type_annotate)
+    end
   end
 end

--- a/glib2/lib/glib2/variant.rb
+++ b/glib2/lib/glib2/variant.rb
@@ -1,0 +1,27 @@
+# Copyright (C) 2015-2022  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module GLib
+  class Variant
+    class << self
+      alias_method :parse_raw, :parse
+
+      def parse(string, type = nil)
+        parse_raw(string, type)
+      end
+    end
+  end
+end

--- a/glib2/test/test-variant.rb
+++ b/glib2/test/test-variant.rb
@@ -45,6 +45,12 @@ class TestGLibVariant < Test::Unit::TestCase
       variant = GLib::Variant.parse("[1, 2, 3]")
       assert_equal([1, 2, 3], variant.value)
     end
+
+    test "value: integer, type: UINT16" do
+      variant = GLib::Variant.parse("65535", GLib::VariantType::UINT16)
+      assert_equal(65535, variant.value)
+      assert_equal("q", variant.type.to_s)
+    end
   end
 
   sub_test_case "#variant_print" do
@@ -71,6 +77,18 @@ class TestGLibVariant < Test::Unit::TestCase
       variant = GLib::Variant.new([1, 2, 3])
       out = variant.variant_print
       assert_equal("[1, 2, 3]", out)
+    end
+
+    test "value: integer, type: UINT16, type_annotate: true" do
+      variant = GLib::Variant.new(65535, GLib::VariantType::UINT16)
+      out = variant.variant_print(true)
+      assert_equal("uint16 65535", out)
+    end
+
+    test "value: int vector, type_anntoate: true" do
+      variant = GLib::Variant.new([1, 2, 3])
+      out = variant.variant_print(true)
+      assert_equal("[int64 1, 2, 3]", out)
     end
   end
 end

--- a/glib2/test/test-variant.rb
+++ b/glib2/test/test-variant.rb
@@ -24,4 +24,53 @@ class TestGLibVariant < Test::Unit::TestCase
                    [variant.type, variant.value])
     end
   end
+
+  sub_test_case ".parse" do
+    test "value: true" do
+      variant = GLib::Variant.parse("true")
+      assert_equal(true, variant.value)
+    end
+
+    test "value: float" do
+      variant = GLib::Variant.parse(Math::PI.to_s)
+      assert_equal(Math::PI, variant.value)
+    end
+
+    test "value: infinity" do
+      variant = GLib::Variant.parse("inf")
+      assert_equal(Float::INFINITY, variant.value)
+    end
+
+    test "value: int vector" do
+      variant = GLib::Variant.parse("[1, 2, 3]")
+      assert_equal([1, 2, 3], variant.value)
+    end
+  end
+
+  sub_test_case "#variant_print" do
+    test "value: true" do
+      variant = GLib::Variant.new(true)
+      out = variant.variant_print
+      assert_equal("true", out)
+    end
+
+    test "value: float" do
+      variant = GLib::Variant.new(Math::PI)
+      out = variant.variant_print
+      ## this may avoid mismatch from rounding error
+      assert_equal(Math::PI, out.to_f)
+    end
+
+    test "value: infinity" do
+      variant = GLib::Variant.new(Float::INFINITY)
+      out = variant.variant_print
+      assert_equal("inf", out)
+    end
+
+    test "value: int vector" do
+      variant = GLib::Variant.new([1, 2, 3])
+      out = variant.variant_print
+      assert_equal("[1, 2, 3]", out)
+    end
+  end
 end


### PR DESCRIPTION
This pull request would add a `GVariant.parse` class method and a `GVariant#variant_print` instance method.

Quoting the changelong:

rbglib-variant.c
- adding an instance method variant_print to GLib::Varaint
- adding a class method GLib::Variant.parse => Glib::Variant

glib2.rb
- adding a dependency for the added file glib2/variant.rb

glib2/variant.rb
- New file
- Renaming Variant.parse => Variant.parse_raw at runtime
- Dispatching to Variant.parse_raw from Variant.parse

test-variant.rb
- Adding tests for .parse, #variant_print methods in GLib::Variant

----

Known Limitations
- This initial change set does not provide any testing for the optional 'type' arg to the final `Variant.parse` method
- The definition for `Variant#print` is incomplete, in this changeset. The optional `type_annotate` arg is defined in the C source code, but then the arg is promptly lost due to the definition of the method interface for Ruby. As such, there's also no testing defined for this generally optional arg.

I'll try to address these in a subsequent change set. Health, all.