### PR TITLE
Fix hello_world example in GTK4

### DIFF
--- a/gtk4/sample/examples/hello_world.rb
+++ b/gtk4/sample/examples/hello_world.rb
@@ -29,8 +29,8 @@ application.signal_connect "activate" do |app|
   win.title = "window"
   win.set_default_size(200, 200)
 
-  button_box = Gtk::ButtonBox.new(:horizontal)
-  win.add(button_box)
+  button_box = Gtk::Box.new(:horizontal)
+  win.set_child(button_box)
 
   button = Gtk::Button.new(:label => "Hello World")
   button.signal_connect "clicked" do
@@ -38,7 +38,7 @@ application.signal_connect "activate" do |app|
     win.destroy
   end
 
-  button_box.add(button)
+  button_box.append(button)
 
   win.show
 end

--- a/gtk4/sample/examples/hello_world.rb
+++ b/gtk4/sample/examples/hello_world.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 #
-# Copyright (C) 2013-2018  Ruby-GNOME2 Project Team
+# Copyright (C) 2013-2022  Ruby-GNOME Project Team
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -16,7 +16,7 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-# example from https://github.com/GNOME/gtk/blob/master/examples/hello-world.c
+# example from https://gitlab.gnome.org/GNOME/gtk/blob/main/examples/hello/hello-world.c
 
 require_relative "utils"
 
@@ -25,22 +25,22 @@ require_gtk4
 application = Gtk::Application.new("org.gtk.example", :flags_none)
 
 application.signal_connect "activate" do |app|
-  win = Gtk::ApplicationWindow.new(app)
-  win.title = "window"
-  win.set_default_size(200, 200)
+  window = Gtk::ApplicationWindow.new(app)
+  window.title = "Window"
+  window.set_default_size(200, 200)
 
-  button_box = Gtk::Box.new(:horizontal)
-  win.set_child(button_box)
+  button = Gtk::Button.new(label: "Hello World")
+  button.set_halign(:center)
+  button.set_valign(:center)
 
-  button = Gtk::Button.new(:label => "Hello World")
   button.signal_connect "clicked" do
     puts "Hello World"
-    win.destroy
+    window.destroy
   end
 
-  button_box.append(button)
+  window.set_child(button)
 
-  win.show
+  window.show
 end
 
-application.run
+app.run


### PR DESCRIPTION
* Update year
* Update link
* Remove Box
  * upstream does not use a box.
* `win` -> `window` 
  * changed the variable name to the same as upstream, although that may not be necessary.