### PR TITLE
Always set wrap_struct_name for rbgobj

### DIFF
--- a/glib2/ext/glib2/rbgobj_type.c
+++ b/glib2/ext/glib2/rbgobj_type.c
@@ -106,6 +106,7 @@ rbgobj_class_info_create_data_type(VALUE klass)
     rb_data_type_t *data_type;
 
     data_type = RB_ZALLOC(rb_data_type_t);
+    data_type->wrap_struct_name = "glib2/rbgobj";
     data_type->function.dmark = cinfo_mark;
     data_type->function.dfree = cinfo_free;
     if (RB_TYPE_P(klass, RUBY_T_CLASS) && klass != rb_cObject) {

--- a/glib2/ext/glib2/rbgobj_type.c
+++ b/glib2/ext/glib2/rbgobj_type.c
@@ -106,7 +106,7 @@ rbgobj_class_info_create_data_type(VALUE klass)
     rb_data_type_t *data_type;
 
     data_type = RB_ZALLOC(rb_data_type_t);
-    data_type->wrap_struct_name = "glib2/rbgobj";
+    data_type->wrap_struct_name = "RGObjClassInfo";
     data_type->function.dmark = cinfo_mark;
     data_type->function.dfree = cinfo_free;
     if (RB_TYPE_P(klass, RUBY_T_CLASS) && klass != rb_cObject) {


### PR DESCRIPTION
Ruby requires all TypedData objects to have a wrap_struct_name. If it's null then ObjectSpace.dump_all will crash when it tries to read it.