### PR TITLE
Fix memory leak in rbgobj

### DIFF
--- a/glib2/ext/glib2/rbgobj_type.c
+++ b/glib2/ext/glib2/rbgobj_type.c
@@ -68,6 +68,7 @@ cinfo_free(void *data)
     RGObjClassInfo *cinfo = data;
     xfree(cinfo->name);
     xfree(cinfo->data_type);
+    xfree(cinfo);
 }
 
 static RGObjClassInfo *

--- a/glib2/ext/glib2/rbgobj_type.c
+++ b/glib2/ext/glib2/rbgobj_type.c
@@ -66,6 +66,7 @@ static void
 cinfo_free(void *data)
 {
     RGObjClassInfo *cinfo = data;
+    g_hash_table_remove(gtype_to_cinfo, GUINT_TO_POINTER(cinfo->gtype));
     xfree(cinfo->name);
     xfree(cinfo->data_type);
     xfree(cinfo);


### PR DESCRIPTION
TypedData objects requires the free function to also manage the allocated data buffer. Since rbgobj is always created with TypedData_Make_Struct, we have to also free the buffer to not leak memory.