### PR TITLE
gtk4: Fix errors and deprecations in sample example files

### DIFF
--- a/gtk4/sample/examples/action-namespace.rb
+++ b/gtk4/sample/examples/action-namespace.rb
@@ -123,7 +123,7 @@ application.signal_connect "activate" do |app|
   button.menu_model = buttonmenu
   button.halign = :center
   button.valign = :start
-  win.add(button)
+  win.set_child(button)
   win.show
 end
 

--- a/gtk4/sample/examples/grid_packing.rb
+++ b/gtk4/sample/examples/grid_packing.rb
@@ -33,7 +33,7 @@ application.signal_connect "activate" do |app|
   grid = Gtk::Grid.new
 
   # Pack the container in the window
-  win.add(grid)
+  win.set_child(grid)
 
   button = Gtk::Button.new(:label => "Button 1")
   button.signal_connect("clicked") { puts "Hello World!" }


### PR DESCRIPTION
This fixes a few deprecation warnings and some errors in the drawing example. The `frame` has [been removed](https://gitlab.gnome.org/GNOME/gtk/-/commit/ece9e7e240bd91fc788343f0b6a9be3ccc52f81c) in the C example, so I removed it as well.

![image](https://user-images.githubusercontent.com/13088/201754559-244c30ef-5275-4dbb-8584-828760c1383b.png)
