### PR TITLE
rsvg2: Fix librsvg/rsvg-cairo.h header check

### DIFF
--- a/rsvg2-no-gi/ext/rsvg2/extconf.rb
+++ b/rsvg2-no-gi/ext/rsvg2/extconf.rb
@@ -66,7 +66,7 @@ have_func("rsvg_handle_get_pixbuf_sub", rsvg_header)
 have_header("librsvg/rsvg-gz.h")
 have_type("RsvgDimensionData", "librsvg/rsvg.h")
 
-have_header("librsvg/rsvg-cairo.h")
+have_header("librsvg/rsvg-cairo.h", ["librsvg/rsvg.h"])
 
 create_pkg_config_file("Ruby/RSVG", package_id, nil, "ruby-rsvg2.pc")
 


### PR DESCRIPTION
The check always fails with current librsvg because the header cannot be included on its own anymore (despite the warning at the top).

Seen while working on:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC