### PR TITLE
gtk4: Add sample/examples/application4

### DIFF
--- a/gtk4/sample/examples/application4/README.md
+++ b/gtk4/sample/examples/application4/README.md
@@ -9,7 +9,5 @@ It is a convenience function for creating multiple GSimpleAction instances and a
 If you write a program in C, it is the best way.
 
 However, the program in this directory doesn't use `add_action_entries` method.
-Instead, it uses `each` method of an array, the element of which is an array of an action name and handler.
-The handler can be a Method object or Proc object.
-You can use built-in methods or make a new one for it.
+Instead, it uses `each` method of an array of action names.
 The way above is flexible and simple.

--- a/gtk4/sample/examples/application4/README.md
+++ b/gtk4/sample/examples/application4/README.md
@@ -1,0 +1,15 @@
+# Step 4: Add a menu
+
+The original files are located in the following directory.
+
+- https://gitlab.gnome.org/GNOME/gtk/-/blob/main/examples/application4
+
+They are written in the C language and use `g_action_map_add_action entries`.
+It is a convenience function for creating multiple GSimpleAction instances and adding them to a GActionMap.
+If you write a program in C, it is the best way.
+
+However, the program in this directory doesn't use `add_action_entries` method.
+Instead, it uses `each` method of an array, the element of which is an array of an action name and handler.
+The handler can be a Method object or Proc object.
+You can use built-in methods or make a new one for it.
+The way above is flexible and simple.

--- a/gtk4/sample/examples/application4/exampleapp.rb
+++ b/gtk4/sample/examples/application4/exampleapp.rb
@@ -1,0 +1,147 @@
+#!/usr/bin/env ruby
+#
+# Copyright (C) 2023  Ruby-GNOME Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# Example from:
+# * https://gitlab.gnome.org/GNOME/gtk/-/blob/main/examples/application4/exampleapp.c
+# * https://gitlab.gnome.org/GNOME/gtk/-/blob/main/examples/application4/exampleappwin.c
+# * https://gitlab.gnome.org/GNOME/gtk/-/blob/main/examples/application4/window.ui
+# * https://gitlab.gnome.org/GNOME/gtk/-/blob/main/examples/application4/gears-menu.ui
+# License: LGPL2.1-or-later
+
+require "gtk4"
+
+class ExampleAppWindow < Gtk::ApplicationWindow
+  type_register
+  class << self
+    def init
+      template = <<~TEMPLATE
+      <?xml version="1.0" encoding="UTF-8"?>
+      <interface>
+        <template class="ExampleAppWindow" parent="GtkApplicationWindow">
+          <property name="title" translatable="yes">Example Application</property>
+          <property name="default-width">600</property>
+          <property name="default-height">400</property>
+          <child type="titlebar">
+            <object class="GtkHeaderBar" id="header">
+              <child type="title">
+                <object class="GtkStackSwitcher" id="tabs">
+                  <property name="stack">stack</property>
+                </object>
+              </child>
+              <child type="end">
+                <object class="GtkMenuButton" id="gears">
+                  <property name="direction">none</property>
+                </object>
+              </child>
+            </object>
+          </child>
+          <child>
+            <object class="GtkBox" id="content_box">
+              <property name="orientation">vertical</property>
+              <child>
+                <object class="GtkStack" id="stack"/>
+              </child>
+            </object>
+          </child>
+        </template>
+      </interface>
+      TEMPLATE
+      set_template(data: template)
+      bind_template_child("stack")
+      bind_template_child("gears")
+    end
+  end
+
+  def initialize(application)
+    menu_ui = <<~MENU
+    <?xml version="1.0" encoding="UTF-8"?>
+    <interface>
+      <menu id="menu">
+        <section>
+          <item>
+            <attribute name="label" translatable="yes">_Preferences</attribute>
+            <attribute name="action">app.preferences</attribute>
+          </item>
+        </section>
+        <section>
+          <item>
+            <attribute name="label" translatable="yes">_Quit</attribute>
+            <attribute name="action">app.quit</attribute>
+          </item>
+        </section>
+      </menu>
+    </interface>
+    MENU
+    super(application: application)
+    builder = Gtk::Builder.new(string: menu_ui)
+    gears.menu_model = builder["menu"]
+  end
+
+  def open(file)
+    basename = file.basename
+    scrolled = Gtk::ScrolledWindow.new
+    scrolled.hexpand = true
+    scrolled.vexpand = true
+    view = Gtk::TextView.new
+    view.editable = false
+    view.cursor_visible = false
+    scrolled.child = view
+    stack.add_titled(scrolled, basename, basename)
+    stream = file.read
+    view.buffer.text = stream.read
+  end
+end
+
+class ExampleApp < Gtk::Application
+  def initialize
+    super("org.gtk.exampleapp", :handles_open)
+
+    signal_connect "startup" do |application|
+      [ # action_name, handler (handler can be a Method object or Proc object)
+        ["preferences"],
+        ["quit", application.method(:quit)]
+      ].each do |action_name, handler|
+        action = Gio::SimpleAction.new(action_name)
+        action.signal_connect("activate") do |_action, _parameter|
+          handler.call if handler
+        end
+        application.add_action(action)
+      end
+      application.set_accels_for_action("app.quit", ["<Control>Q"])
+    end
+    signal_connect "activate" do |application|
+      window = ExampleAppWindow.new(application)
+      window.present
+    end
+    signal_connect "open" do |application, files, hint|
+      window = application.windows[0] || ExampleAppWindow.new(application)
+      files.each do |file|
+        window.open(file)
+      end
+      window.present
+    end
+  end
+end
+
+app = ExampleApp.new
+
+# Gtk::Application#run needs C style argv ([prog, arg1, arg2, ...,argn]).
+# The ARGV ruby variable only contains the arguments ([arg1, arg2, ...,argb])
+# and not the program name. We have to add it explicitly.
+
+app.run([$PROGRAM_NAME] + ARGV)

--- a/gtk4/sample/examples/application4/exampleapp.rb
+++ b/gtk4/sample/examples/application4/exampleapp.rb
@@ -112,13 +112,13 @@ class ExampleApp < Gtk::Application
     super("org.gtk.exampleapp", :handles_open)
 
     signal_connect "startup" do |application|
-      [ # action_name, handler (handler can be a Method object or Proc object)
-        ["preferences"],
-        ["quit", application.method(:quit)]
-      ].each do |action_name, handler|
+      [
+        "preferences",
+        "quit"
+      ].each do |action_name|
         action = Gio::SimpleAction.new(action_name)
         action.signal_connect("activate") do |_action, _parameter|
-          handler.call if handler
+          __send__("#{action_name}_activated")
         end
         application.add_action(action)
       end
@@ -135,6 +135,15 @@ class ExampleApp < Gtk::Application
       end
       window.present
     end
+  end
+
+  private
+
+  def preferences_activated
+  end
+
+  def quit_activated
+    quit
   end
 end
 


### PR DESCRIPTION
The original C program uses `gtk_action_map_add_action_entries` function.

- https://gitlab.gnome.org/GNOME/gtk/-/blob/main/examples/application4

But the program in this directory uses Ruby `each` iteration instead of the function above.
It makes the program simple and easy to understand.
