### PR TITLE
Fix a TypeError in rclosure_invalidate

### DIFF
--- a/glib2/ext/glib2/rbgobj_closure.c
+++ b/glib2/ext/glib2/rbgobj_closure.c
@@ -169,7 +169,7 @@ rclosure_invalidate(G_GNUC_UNUSED gpointer data, GClosure *closure)
         g_closure_unref(closure);
         VALUE obj = rbgobj_ruby_object_from_instance2(object, FALSE);
         if (!NIL_P(rclosure->rb_holder) && !NIL_P(obj)) {
-            rbgobj_object_remove_relative(obj, rclosure->rb_holder);
+            rbgobj_remove_relative(obj, id_closures, rclosure->rb_holder);
         }
     }
     g_list_free(rclosure->objects);


### PR DESCRIPTION
Builds are failing for alexandria when upgrading to ruby-gnome 4.0.9 or later: https://github.com/mvz/alexandria-book-collection-manager/pull/225. All specs pass, but then the exit code somehow indicates failure anyway.

The problem becomes clearer when running with debug flags:

```
$ RUBYOPT="-d" bundle exec rspec spec/alexandria/ui/new_book_dialog_manual_spec.rb
[snip]
4 examples, 0 failures

Exception `TypeError' at /home/matijs/.rbenv/versions/3.2.2/bin/bundle - wrong argument type Gtk::CellRendererText (expected GLib::Object)
```

Sometimes the wrong argument type is some other Gtk type, like Gtk::Entry or Gtk::Dialog.

I eventually found out that the TypeError occurs in the call to `rbgobj_object_remove_relative` in `rclosure_invalidate`.

I'm not entirely sure what's going on, but changing it to `rbgobj_remove_relative` makes the error go away.