### PR TITLE
Fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,4 +102,4 @@ See [gtk3/sample/](/gtk3/sample) directory for details.
 
 ## Project Website
 
-[https://ruby-gnome2.osdn.jp/](https://ruby-gnome2.osdn.jp/)
+[https://ruby-gnome.github.io/](https://ruby-gnome.github.io/)

--- a/atk-no-gi/README
+++ b/atk-no-gi/README
@@ -27,4 +27,4 @@ Copying
 
 Project Website
 ---------------
-   https://ruby-gnome2.osdn.jp/
+   https://ruby-gnome.github.io/

--- a/atk/README.md
+++ b/atk/README.md
@@ -21,4 +21,4 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 ## Project Websites
 
 *   https://github.com/ruby-gnome/ruby-gnome
-*   https://ruby-gnome2.osdn.jp/
+*   https://ruby-gnome.github.io/

--- a/atk/atk.gemspec
+++ b/atk/atk.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.description   = "Ruby/ATK is a Ruby binding of ATK-1.0.x."
   s.author        = "The Ruby-GNOME Project Team"
   s.email         = "ruby-gnome2-devel-en@lists.sourceforge.net"
-  s.homepage      = "https://ruby-gnome2.osdn.jp/"
+  s.homepage      = "https://ruby-gnome.github.io/"
   s.licenses      = ["LGPL-2.1+"]
   s.version       = ruby_glib2_version
   s.extensions    = ["dependency-check/Rakefile"]

--- a/cairo-gobject/README.md
+++ b/cairo-gobject/README.md
@@ -5,7 +5,7 @@ Ruby/CairoGObject is a Ruby binding of cairo-gobject.
 ## Requirements
 
 * Ruby/GLib2 in
-  [Ruby-GNOME2](https://ruby-gnome2.osdn.jp/)
+  [Ruby-GNOME2](https://ruby-gnome.github.io/)
 * [rcairo](https://github.com/rcairo/rcairo)
 * [cairo](http://cairographics.org/) GObject binding
 
@@ -22,4 +22,4 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 
 ## Project Website
 
-https://ruby-gnome2.osdn.jp/
+https://ruby-gnome.github.io/

--- a/cairo-gobject/cairo-gobject.gemspec
+++ b/cairo-gobject/cairo-gobject.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.description   = "Ruby/CairoGObject is a Ruby binding of cairo-gobject."
   s.author        = "The Ruby-GNOME Project Team"
   s.email         = "ruby-gnome2-devel-en@lists.sourceforge.net"
-  s.homepage      = "https://ruby-gnome2.osdn.jp/"
+  s.homepage      = "https://ruby-gnome.github.io/"
   s.licenses      = ["LGPL-2.1+"]
   s.version       = ruby_glib2_version
   s.extensions    = ["ext/#{s.name}/extconf.rb"]

--- a/clutter-gdk/README.md
+++ b/clutter-gdk/README.md
@@ -5,7 +5,7 @@ Ruby/ClutterGDK is a Ruby binding of GDK specific API of Clutter.
 ## Requirements
 
 * Ruby/Clutter and Ruby/GTK3 in
-  [Ruby-GNOME2](https://ruby-gnome2.osdn.jp/)
+  [Ruby-GNOME2](https://ruby-gnome.github.io/)
 * [Clutter-gdk](http://blogs.gnome.org/clutter/)
 
 ## Install
@@ -26,4 +26,4 @@ https://developer.gnome.org/clutter/stable/clutter-GDK-Specific-Support.html
 ## Project Websites
 
 *  https://github.com/ruby-gnome/ruby-gnome
-*  https://ruby-gnome2.osdn.jp/
+*  https://ruby-gnome.github.io/

--- a/clutter-gdk/clutter-gdk.gemspec
+++ b/clutter-gdk/clutter-gdk.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
     "Ruby/ClutterGDK is a Ruby binding of GDK specific API of Clutter."
   s.author        = "The Ruby-GNOME Project Team"
   s.email         = "ruby-gnome2-devel-en@lists.sourceforge.net"
-  s.homepage      = "https://ruby-gnome2.osdn.jp/"
+  s.homepage      = "https://ruby-gnome.github.io/"
   s.licenses      = ["LGPL-2.1+"]
   s.version       = ruby_glib2_version
   s.require_paths = ["lib"]

--- a/clutter-gstreamer/README.md
+++ b/clutter-gstreamer/README.md
@@ -5,7 +5,7 @@ Ruby/ClutterGStreamer is a Ruby binding of Clutter-GStreamer.
 ## Requirements
 
 * Ruby/Clutter and Ruby/GStreamer in
-  [Ruby-GNOME2](https://ruby-gnome2.osdn.jp/)
+  [Ruby-GNOME2](https://ruby-gnome.github.io/)
 * [Clutter-GStreamer](http://blogs.gnome.org/clutter/)
 
 ## Install
@@ -28,4 +28,4 @@ are licensed under the LGPL v2.1 or later.
 
 ## Project Website
 
-https://ruby-gnome2.osdn.jp/
+https://ruby-gnome.github.io/

--- a/clutter-gstreamer/clutter-gstreamer.gemspec
+++ b/clutter-gstreamer/clutter-gstreamer.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.description   = "Ruby/ClutterGStreamer is a Ruby binding of Clutter-GStreamer."
   s.author        = "The Ruby-GNOME Project Team"
   s.email         = "ruby-gnome2-devel-en@lists.sourceforge.net"
-  s.homepage      = "https://ruby-gnome2.osdn.jp/"
+  s.homepage      = "https://ruby-gnome.github.io/"
   s.licenses      = ["LGPL-2.1+"]
   s.version       = ruby_glib2_version
   s.extensions    = ["dependency-check/Rakefile"]

--- a/clutter-gtk/README.md
+++ b/clutter-gtk/README.md
@@ -5,7 +5,7 @@ Ruby/ClutterGTK is a Ruby binding of Clutter-GTK.
 ## Requirements
 
 * Ruby/Clutter and Ruby/GTK3 in
-  [Ruby-GNOME2](https://ruby-gnome2.osdn.jp/)
+  [Ruby-GNOME2](https://ruby-gnome.github.io/)
 * [Clutter-GTK](http://blogs.gnome.org/clutter/)
 
 ## Install
@@ -28,4 +28,4 @@ are licensed under the LGPL v2.1 or later.
 
 ## Project Website
 
-https://ruby-gnome2.osdn.jp/
+https://ruby-gnome.github.io/

--- a/clutter-gtk/clutter-gtk.gemspec
+++ b/clutter-gtk/clutter-gtk.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.description   = "Ruby/ClutterGTK is a Ruby binding of Clutter-GTK."
   s.author        = "The Ruby-GNOME Project Team"
   s.email         = "ruby-gnome2-devel-en@lists.sourceforge.net"
-  s.homepage      = "https://ruby-gnome2.osdn.jp/"
+  s.homepage      = "https://ruby-gnome.github.io/"
   s.licenses      = ["LGPL-2.1+"]
   s.version       = ruby_glib2_version
   s.extensions    = ["dependency-check/Rakefile"]

--- a/clutter/README.md
+++ b/clutter/README.md
@@ -5,7 +5,7 @@ Ruby/Clutter is a Ruby binding of Clutter.
 ## Requirements
 
 * Ruby/GObjectIntrospection in
-  [Ruby-GNOME2](https://ruby-gnome2.osdn.jp/)
+  [Ruby-GNOME2](https://ruby-gnome.github.io/)
 * [Clutter](http://blogs.gnome.org/clutter/)
 
 ## Install
@@ -28,4 +28,4 @@ are licensed under the LGPL v2.1 or later.
 
 ## Project Website
 
-https://ruby-gnome2.osdn.jp/
+https://ruby-gnome.github.io/

--- a/clutter/clutter.gemspec
+++ b/clutter/clutter.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.description   = "Ruby/Clutter is a Ruby binding of Clutter."
   s.author        = "The Ruby-GNOME Project Team"
   s.email         = "ruby-gnome2-devel-en@lists.sourceforge.net"
-  s.homepage      = "https://ruby-gnome2.osdn.jp/"
+  s.homepage      = "https://ruby-gnome.github.io/"
   s.licenses      = ["LGPL-2.1+"]
   s.version       = ruby_glib2_version
   s.extensions    = ["dependency-check/Rakefile"]

--- a/gdk3-no-gi/README.md
+++ b/gdk3-no-gi/README.md
@@ -5,7 +5,7 @@ Ruby/GDK3 is a Ruby binding of GDK 3.
 ## Requirements
 
 * Ruby/GLib2, Ruby/ATK, Ruby/Pango and Ruby/GdkPixbuf2 in
-  [Ruby-GNOME2](https://ruby-gnome2.osdn.jp/)
+  [Ruby-GNOME2](https://ruby-gnome.github.io/)
 * [rcairo](https://github.com/rcairo/rcairo)
 * [GTK+](http://cairographics.org/) 3.4.2 or later
 
@@ -22,4 +22,4 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 
 ## Project Website
 
-https://ruby-gnome2.osdn.jp/
+https://ruby-gnome.github.io/

--- a/gdk3/README.md
+++ b/gdk3/README.md
@@ -5,7 +5,7 @@ Ruby/GDK3 is a Ruby binding of GDK 3.
 ## Requirements
 
 * Ruby/GLib2, Ruby/ATK, Ruby/Pango and Ruby/GdkPixbuf2 in
-  [Ruby-GNOME2](https://ruby-gnome2.osdn.jp/)
+  [Ruby-GNOME2](https://ruby-gnome.github.io/)
 * [rcairo](https://github.com/rcairo/rcairo)
 * [GTK+](https://www.gtk.org/) 3.4.2 or later
 
@@ -22,4 +22,4 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 
 ## Project Website
 
-https://ruby-gnome2.osdn.jp/
+https://ruby-gnome.github.io/

--- a/gdk3/gdk3.gemspec
+++ b/gdk3/gdk3.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.description   = "Ruby/GDK3 is a Ruby binding of GDK-3.x."
   s.author        = "The Ruby-GNOME Project Team"
   s.email         = "ruby-gnome2-devel-en@lists.sourceforge.net"
-  s.homepage      = "https://ruby-gnome2.osdn.jp/"
+  s.homepage      = "https://ruby-gnome.github.io/"
   s.licenses      = ["LGPL-2.1+"]
   s.version       = ruby_glib2_version
   s.extensions    = ["dependency-check/Rakefile"]

--- a/gdk4/README.md
+++ b/gdk4/README.md
@@ -6,7 +6,7 @@ https://developer.gnome.org/gdk4/3.90/
 ## Requirements
 
 * Ruby/GLib2, Ruby/ATK, Ruby/Pango and Ruby/GdkPixbuf2 in
-  [Ruby-GNOME2](https://ruby-gnome2.osdn.jp/)
+  [Ruby-GNOME2](https://ruby-gnome.github.io/)
 * [rcairo](https://github.com/rcairo/rcairo)
 * [GTK+](https://www.gtk.org/) 3.93 or later
 
@@ -55,4 +55,4 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 
 ## Project Website
 
-https://ruby-gnome2.osdn.jp/
+https://ruby-gnome.github.io/

--- a/gdk4/gdk4.gemspec
+++ b/gdk4/gdk4.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.description   = "Ruby/GDK4 is a Ruby binding of GDK-4.x."
   s.author        = "The Ruby-GNOME Project Team"
   s.email         = "ruby-gnome2-devel-en@lists.sourceforge.net"
-  s.homepage      = "https://ruby-gnome2.osdn.jp/"
+  s.homepage      = "https://ruby-gnome.github.io/"
   s.licenses      = ["LGPL-2.1+"]
   s.version       = ruby_glib2_version
   s.extensions    = ["dependency-check/Rakefile"]

--- a/gdk_pixbuf2-no-gi/README
+++ b/gdk_pixbuf2-no-gi/README
@@ -26,4 +26,4 @@ Copying
 
 Project Website
 ---------------
-   https://ruby-gnome2.osdn.jp/
+   https://ruby-gnome.github.io/

--- a/gdk_pixbuf2/README.md
+++ b/gdk_pixbuf2/README.md
@@ -21,4 +21,4 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 ## Project Websites
 
 * https://github.com/ruby-gnome/ruby-gnome
-* https://ruby-gnome2.osdn.jp/
+* https://ruby-gnome.github.io/

--- a/gdk_pixbuf2/gdk_pixbuf2.gemspec
+++ b/gdk_pixbuf2/gdk_pixbuf2.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.description   = "Ruby/GdkPixbuf2 is a Ruby binding of GdkPixbuf-2.x."
   s.author        = "The Ruby-GNOME Project Team"
   s.email         = "ruby-gnome2-devel-en@lists.sourceforge.net"
-  s.homepage      = "https://ruby-gnome2.osdn.jp/"
+  s.homepage      = "https://ruby-gnome.github.io/"
   s.licenses      = ["LGPL-2.1+"]
   s.version       = ruby_glib2_version
   s.extensions    = ["dependency-check/Rakefile"]

--- a/gegl/README.md
+++ b/gegl/README.md
@@ -5,7 +5,7 @@ Ruby/GEGL is a Ruby binding of GEGL.
 ## Requirements
 
 * Ruby/GObjectIntrospection in
-  [Ruby-GNOME2](https://ruby-gnome2.osdn.jp/)
+  [Ruby-GNOME2](https://ruby-gnome.github.io/)
 * [GEGL](https://gegl.org/)
 
 ## Install
@@ -21,4 +21,4 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 
 ## Project Website
 
-https://ruby-gnome2.osdn.jp/
+https://ruby-gnome.github.io/

--- a/gegl/gegl.gemspec
+++ b/gegl/gegl.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.description   = "Ruby/GEGL is a Ruby binding of GEGL."
   s.author        = "The Ruby-GNOME Project Team"
   s.email         = "ruby-gnome2-devel-en@lists.sourceforge.net"
-  s.homepage      = "https://ruby-gnome2.osdn.jp/"
+  s.homepage      = "https://ruby-gnome.github.io/"
   s.licenses      = ["LGPL-2.1+"]
   s.version       = ruby_glib2_version
   s.extensions    = ["dependency-check/Rakefile"]

--- a/gio2/README.md
+++ b/gio2/README.md
@@ -5,7 +5,7 @@ Ruby/GIO2 is a Ruby binding of gio-2.0.x.
 ## Requirements
 
 * Ruby/GObjectIntrospection in
-  [Ruby-GNOME2](https://ruby-gnome2.osdn.jp/)
+  [Ruby-GNOME2](https://ruby-gnome.github.io/)
 * [GIO](http://library.gnome.org/devel/gio/stable)
 
 ## Install
@@ -21,4 +21,4 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 
 ## Project Website
 
-https://ruby-gnome2.osdn.jp/
+https://ruby-gnome.github.io/

--- a/gio2/gio2.gemspec
+++ b/gio2/gio2.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
     "for desktop applications (such as networking and D-Bus support)."
   s.author        = "The Ruby-GNOME Project Team"
   s.email         = "ruby-gnome2-devel-en@lists.sourceforge.net"
-  s.homepage      = "https://ruby-gnome2.osdn.jp/"
+  s.homepage      = "https://ruby-gnome.github.io/"
   s.licenses      = ["LGPL-2.1+"]
   s.version       = ruby_glib2_version
   s.extensions    = ["ext/#{s.name}/extconf.rb"]

--- a/glib2/README.md
+++ b/glib2/README.md
@@ -24,4 +24,4 @@ the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 
 ## Project Website
 
-https://ruby-gnome2.osdn.jp/
+https://ruby-gnome.github.io/

--- a/glib2/glib2.gemspec
+++ b/glib2/glib2.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
     "many useful utility features."
   s.author        = "The Ruby-GNOME Project Team"
   s.email         = "ruby-gnome2-devel-en@lists.sourceforge.net"
-  s.homepage      = "https://ruby-gnome2.osdn.jp/"
+  s.homepage      = "https://ruby-gnome.github.io/"
   s.licenses      = ["LGPL-2.1+"]
   s.version       = ruby_glib2_version
   s.extensions    = ["ext/#{s.name}/extconf.rb"]

--- a/glib2/lib/gnome/rake/package-task.rb
+++ b/glib2/lib/gnome/rake/package-task.rb
@@ -126,7 +126,7 @@ module GNOME
         @description = ""
         @author = "The Ruby-GNOME2 Project Team"
         @email = "ruby-gnome2-devel-en@lists.sourceforge.net"
-        @homepage = "https://ruby-gnome2.osdn.jp/"
+        @homepage = "https://ruby-gnome.github.io/"
         @external_packages = []
       end
 

--- a/gnumeric/README.md
+++ b/gnumeric/README.md
@@ -5,7 +5,7 @@ Ruby/Gnumeric is a Ruby binding of Gnumeric.
 ## Requirements
 
 * Ruby/GOffice in
-  [Ruby-GNOME2](https://ruby-gnome2.osdn.jp/)
+  [Ruby-GNOME2](https://ruby-gnome.github.io/)
 * [Gnumeric](http://www.gnumeric.org/)
 
 ## Install
@@ -21,5 +21,5 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 
 ## Project Websites
 
-*   https://ruby-gnome2.osdn.jp/
+*   https://ruby-gnome.github.io/
 *   https://github.com/ruby-gnome/ruby-gnome

--- a/gnumeric/gnumeric.gemspec
+++ b/gnumeric/gnumeric.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.description = "Ruby/Gnumeric is a Ruby binding of Gnumeric."
   s.author        = "The Ruby-GNOME Project Team"
   s.email         = "ruby-gnome2-devel-en@lists.sourceforge.net"
-  s.homepage      = "https://ruby-gnome2.osdn.jp/"
+  s.homepage      = "https://ruby-gnome.github.io/"
   s.licenses      = ["LGPL-2.1+"]
   s.version       = ruby_glib2_version
   s.extensions    = ["dependency-check/Rakefile"]

--- a/gobject-introspection/README.md
+++ b/gobject-introspection/README.md
@@ -5,7 +5,7 @@ Ruby/GObjectIntrospection is a Ruby binding of GObject Introspect.
 ## Requirements
 
 * Ruby/GLib2 in
-  [Ruby-GNOME2](https://ruby-gnome2.osdn.jp/)
+  [Ruby-GNOME2](https://ruby-gnome.github.io/)
 * [GObject Introspection](http://live.gnome.org/GObjectIntrospection)
 
 ## Install
@@ -21,4 +21,4 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 
 ## Project Website
 
-https://ruby-gnome2.osdn.jp/
+https://ruby-gnome.github.io/

--- a/gobject-introspection/gobject-introspection.gemspec
+++ b/gobject-introspection/gobject-introspection.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
     "of any GObject C libraries"
   s.author        = "The Ruby-GNOME Project Team"
   s.email         = "ruby-gnome2-devel-en@lists.sourceforge.net"
-  s.homepage      = "https://ruby-gnome2.osdn.jp/"
+  s.homepage      = "https://ruby-gnome.github.io/"
   s.licenses      = ["LGPL-2.1+"]
   s.version       = ruby_glib2_version
   s.extensions    = ["ext/#{s.name}/extconf.rb"]

--- a/goffice/README.md
+++ b/goffice/README.md
@@ -5,7 +5,7 @@ Ruby/GOffice is a Ruby binding of GOffice.
 ## Requirements
 
 * Ruby/GTK3 and Ruby/GSF in
-  [Ruby-GNOME2](https://ruby-gnome2.osdn.jp/)
+  [Ruby-GNOME2](https://ruby-gnome.github.io/)
 * [GOffice](https://developer.gnome.org/goffice/)
 
 ## Install
@@ -21,5 +21,5 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 
 ## Project Websites
 
-*   https://ruby-gnome2.osdn.jp/
+*   https://ruby-gnome.github.io/
 *   https://github.com/ruby-gnome/ruby-gnome

--- a/goffice/goffice.gemspec
+++ b/goffice/goffice.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.description   = "Ruby/GOFFICE is a Ruby binding of GOFFICE."
   s.author        = "The Ruby-GNOME Project Team"
   s.email         = "ruby-gnome2-devel-en@lists.sourceforge.net"
-  s.homepage      = "https://ruby-gnome2.osdn.jp/"
+  s.homepage      = "https://ruby-gnome.github.io/"
   s.licenses      = ["LGPL-2.1+"]
   s.version       = ruby_glib2_version
   s.extensions    = ["dependency-check/Rakefile"]

--- a/gsf/README.md
+++ b/gsf/README.md
@@ -5,7 +5,7 @@ Ruby/GSF is a Ruby binding of GSF which is needed by GOffice.
 ## Requirements
 
 * Ruby/GIO2 in
-  [Ruby-GNOME2](https://ruby-gnome2.osdn.jp/)
+  [Ruby-GNOME2](https://ruby-gnome.github.io/)
 * [GSF](https://developer.gnome.org/gsf/)
 
 ## Install
@@ -21,5 +21,5 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 
 ## Project Websites
 
-*   https://ruby-gnome2.osdn.jp/
+*   https://ruby-gnome.github.io/
 *   https://github.com/ruby-gnome/ruby-gnome

--- a/gsf/gsf.gemspec
+++ b/gsf/gsf.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.description   = "Ruby/GSF is a Ruby binding of GSF."
   s.author        = "The Ruby-GNOME Project Team"
   s.email         = "ruby-gnome2-devel-en@lists.sourceforge.net"
-  s.homepage      = "https://ruby-gnome2.osdn.jp/"
+  s.homepage      = "https://ruby-gnome.github.io/"
   s.licenses      = ["LGPL-2.1+"]
   s.version       = ruby_glib2_version
   s.extensions    = ["dependency-check/Rakefile"]

--- a/gstreamer/README.md
+++ b/gstreamer/README.md
@@ -5,7 +5,7 @@ Ruby/GStreamer is a Ruby binding for GStreamer.
 ## Requirements
 
 * Ruby/GLib2 and Ruby/GObjectIntrospection in
-  [Ruby-GNOME2](https://ruby-gnome2.osdn.jp/)
+  [Ruby-GNOME2](https://ruby-gnome.github.io/)
 * [GStreamer](http://gstreamer.freedesktop.org/)
 
 ## Install
@@ -28,4 +28,4 @@ are licensed under the LGPL v2.1 or later.
 
 ## Project Website
 
-https://ruby-gnome2.osdn.jp/
+https://ruby-gnome.github.io/

--- a/gstreamer/gstreamer.gemspec
+++ b/gstreamer/gstreamer.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.description   = "Ruby/GStreamer is a Ruby binding for GStreamer."
   s.author        = "The Ruby-GNOME Project Team"
   s.email         = "ruby-gnome2-devel-en@lists.sourceforge.net"
-  s.homepage      = "https://ruby-gnome2.osdn.jp/"
+  s.homepage      = "https://ruby-gnome.github.io/"
   s.licenses      = ["LGPL-2.1+"]
   s.version       = ruby_glib2_version
   s.extensions    = ["ext/#{s.name}/extconf.rb"]

--- a/gtk3-no-gi/README.md
+++ b/gtk3-no-gi/README.md
@@ -5,7 +5,7 @@ Ruby/GTK3 is a Ruby binding of GTK 3.
 ## Requirements
 
 * Ruby/GLib2, Ruby/ATK, Ruby/Pango, Ruby/GdkPixbuf2 and Ruby/GTK3 in
-  [Ruby-GNOME2](https://ruby-gnome2.osdn.jp/)
+  [Ruby-GNOME2](https://ruby-gnome.github.io/)
 * [rcairo](https://github.com/rcairo/rcairo)
 * [GTK+](http://www.gtk.org/) 3.4.2 or later
 
@@ -22,4 +22,4 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 
 ## Project Website
 
-https://ruby-gnome2.osdn.jp/
+https://ruby-gnome.github.io/

--- a/gtk3/README.md
+++ b/gtk3/README.md
@@ -6,7 +6,7 @@ Ruby/GTK3 is a Ruby binding of GTK+ 3.
 
 * Ruby/GLib2, Ruby/ATK, Ruby/Pango, Ruby/GdkPixbuf2, Ruby/GIO2,
   Ruby/GDK3, Ruby/GObjectIntrospection and Ruby/GTK3 in
-  [Ruby-GNOME](https://ruby-gnome2.osdn.jp/)
+  [Ruby-GNOME](https://ruby-gnome.github.io/)
 * [rcairo](https://github.com/rcairo/rcairo)
 * [GTK+](http://www.gtk.org/) 3.4.2 or later
 
@@ -31,4 +31,4 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 ## Project Websites
 
 * https://github.com/ruby-gnome/ruby-gnome
-* https://ruby-gnome2.osdn.jp/
+* https://ruby-gnome.github.io/

--- a/gtk3/gtk3.gemspec
+++ b/gtk3/gtk3.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.description   = "Ruby/GTK3 is a Ruby binding of GTK+-3.x."
   s.author        = "The Ruby-GNOME Project Team"
   s.email         = "ruby-gnome2-devel-en@lists.sourceforge.net"
-  s.homepage      = "https://ruby-gnome2.osdn.jp/"
+  s.homepage      = "https://ruby-gnome.github.io/"
   s.licenses      = ["LGPL-2.1+"]
   s.version       = ruby_glib2_version
   s.extensions    = ["ext/#{s.name}/extconf.rb"]

--- a/gtk4/README.md
+++ b/gtk4/README.md
@@ -6,7 +6,7 @@ Ruby/GTK4 is a Ruby binding of GTK+ 4.
 
 * Ruby/GLib2, Ruby/ATK, Ruby/Pango, Ruby/GdkPixbuf2, Ruby/GIO2,
   Ruby/GDK4, Ruby/GObjectIntrospection and Ruby/GTK4 in
-  [Ruby-GNOME2](https://ruby-gnome2.osdn.jp/)
+  [Ruby-GNOME2](https://ruby-gnome.github.io/)
 * [rcairo](https://github.com/rcairo/rcairo)
 * [GTK+](http://www.gtk.org/)
 
@@ -28,4 +28,4 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 ## Project Websites
 
 * https://github.com/ruby-gnome/ruby-gnome
-* https://ruby-gnome2.osdn.jp/
+* https://ruby-gnome.github.io/

--- a/gtk4/gtk4.gemspec
+++ b/gtk4/gtk4.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.description   = "Ruby/GTK4 is a Ruby binding of GTK+-4.x."
   s.author        = "The Ruby-GNOME Project Team"
   s.email         = "ruby-gnome2-devel-en@lists.sourceforge.net"
-  s.homepage      = "https://ruby-gnome2.osdn.jp/"
+  s.homepage      = "https://ruby-gnome.github.io/"
   s.licenses      = ["LGPL-2.1+"]
   s.version       = ruby_glib2_version
   s.extensions    = ["ext/#{s.name}/extconf.rb"]

--- a/gtksourceview3-no-gi/README.md
+++ b/gtksourceview3-no-gi/README.md
@@ -5,7 +5,7 @@ Ruby/GtkSourceView3 is a Ruby binding of gtksourceview-3.x.
 ## Requirements
 
 * Ruby/GTK3 in
-  [Ruby-GNOME2](https://ruby-gnome2.osdn.jp/)
+  [Ruby-GNOME2](https://ruby-gnome.github.io/)
 * [GtkSourceView](http://projects.gnome.org/gtksourceview/) 3.4.2 or later
 
 ## Install
@@ -21,4 +21,4 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 
 ## Project Website
 
-https://ruby-gnome2.osdn.jp/
+https://ruby-gnome.github.io/

--- a/gtksourceview3/README.md
+++ b/gtksourceview3/README.md
@@ -5,7 +5,7 @@ Ruby/GtkSourceView3 is a Ruby binding of gtksourceview-3.x.
 ## Requirements
 
 * Ruby/GTK3 in
-  [Ruby-GNOME2](https://ruby-gnome2.osdn.jp/)
+  [Ruby-GNOME2](https://ruby-gnome.github.io/)
 * [GtkSourceView](http://projects.gnome.org/gtksourceview/) 3.4.2 or later
 
 ## Install
@@ -21,4 +21,4 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 
 ## Project Website
 
-https://ruby-gnome2.osdn.jp/
+https://ruby-gnome.github.io/

--- a/gtksourceview3/gtksourceview3.gemspec
+++ b/gtksourceview3/gtksourceview3.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.description   = "Ruby/GtkSourceView3 is a Ruby binding of gtksourceview-3.x."
   s.author        = "The Ruby-GNOME Project Team"
   s.email         = "ruby-gnome2-devel-en@lists.sourceforge.net"
-  s.homepage      = "https://ruby-gnome2.osdn.jp/"
+  s.homepage      = "https://ruby-gnome.github.io/"
   s.licenses      = ["LGPL-2.1+"]
   s.version       = ruby_glib2_version
   s.extensions    = ["dependency-check/Rakefile"]

--- a/gtksourceview4/README.md
+++ b/gtksourceview4/README.md
@@ -5,7 +5,7 @@ Ruby/GtkSourceView4 is a Ruby binding of gtksourceview-4.x.
 ## Requirements
 
 * Ruby/GTK3 in
-  [Ruby-GNOME2](https://ruby-gnome2.osdn.jp/)
+  [Ruby-GNOME2](https://ruby-gnome.github.io/)
 * [GtkSourceView](http://projects.gnome.org/gtksourceview/) 4.0.0 or later
 
 ## Install
@@ -21,4 +21,4 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 
 ## Project Website
 
-https://ruby-gnome2.osdn.jp/
+https://ruby-gnome.github.io/

--- a/gtksourceview4/gtksourceview4.gemspec
+++ b/gtksourceview4/gtksourceview4.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.description   = "Ruby/GtkSourceView4 is a Ruby binding of gtksourceview-4.x."
   s.author        = "The Ruby-GNOME Project Team"
   s.email         = "ruby-gnome2-devel-en@lists.sourceforge.net"
-  s.homepage      = "https://ruby-gnome2.osdn.jp/"
+  s.homepage      = "https://ruby-gnome.github.io/"
   s.licenses      = ["LGPL-2.1+"]
   s.version       = ruby_glib2_version
   s.extensions    = ["dependency-check/Rakefile"]

--- a/gvlc/README.md
+++ b/gvlc/README.md
@@ -33,4 +33,4 @@ Copying
 
 Project Website
 ---------------
-   https://ruby-gnome2.osdn.jp/
+   https://ruby-gnome.github.io/

--- a/gvlc/gvlc.gemspec
+++ b/gvlc/gvlc.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.description   = "Ruby/VLC is a Ruby binding of libVLC for Ruby/GTK."
   s.author        = "The Ruby-GNOME Project Team"
   s.email         = "ruby-gnome2-devel-en@lists.sourceforge.net"
-  s.homepage      = "https://ruby-gnome2.osdn.jp/"
+  s.homepage      = "https://ruby-gnome.github.io/"
   s.licenses      = ["LGPL-2.1+"]
   s.version       = ruby_glib2_version
   s.extensions    = ["ext/#{s.name}/extconf.rb"]

--- a/libsecret/README.md
+++ b/libsecret/README.md
@@ -5,7 +5,7 @@ Ruby/libsecret is a Ruby binding of libsecret.
 ## Requirements
 
 * Ruby/GObjectIntrospection in
-  [Ruby-GNOME2](https://ruby-gnome2.osdn.jp/)
+  [Ruby-GNOME2](https://ruby-gnome.github.io/)
 * [libsecret](https://wiki.gnome.org/Projects/Libsecret)
 
 ## Install
@@ -21,4 +21,4 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 
 ## Project Website
 
-https://ruby-gnome2.osdn.jp/
+https://ruby-gnome.github.io/

--- a/libsecret/libsecret.gemspec
+++ b/libsecret/libsecret.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.description   = "Ruby/libsecret is a Ruby binding of libsecret."
   s.author        = "The Ruby-GNOME Project Team"
   s.email         = "ruby-gnome2-devel-en@lists.sourceforge.net"
-  s.homepage      = "https://ruby-gnome2.osdn.jp/"
+  s.homepage      = "https://ruby-gnome.github.io/"
   s.licenses      = ["LGPL-2.1+"]
   s.version       = ruby_glib2_version
   s.extensions    = ["dependency-check/Rakefile"]

--- a/pango-no-gi/README
+++ b/pango-no-gi/README
@@ -29,4 +29,4 @@ Copying
 
 Project Website
 ---------------
-   https://ruby-gnome2.osdn.jp/
+   https://ruby-gnome.github.io/

--- a/pango/README.md
+++ b/pango/README.md
@@ -21,5 +21,5 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 
 ## Project Websites
 
-*   https://ruby-gnome2.osdn.jp/
+*   https://ruby-gnome.github.io/
 *   https://github.com/ruby-gnome/ruby-gnome

--- a/pango/pango.gemspec
+++ b/pango/pango.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.description   = "Ruby/Pango is a Ruby binding of pango-1.x based on GObject-Introspection."
   s.author        = "The Ruby-GNOME Project Team"
   s.email         = "ruby-gnome2-devel-en@lists.sourceforge.net"
-  s.homepage      = "https://ruby-gnome2.osdn.jp/"
+  s.homepage      = "https://ruby-gnome.github.io/"
   s.licenses      = ["LGPL-2.1+"]
   s.version       = ruby_glib2_version
   s.extensions    = ["ext/#{s.name}/extconf.rb"]

--- a/poppler-no-gi/README
+++ b/poppler-no-gi/README
@@ -32,4 +32,4 @@ Copying
 
 Project Website
 ---------------
-   https://ruby-gnome2.osdn.jp/
+   https://ruby-gnome.github.io/

--- a/poppler/README.md
+++ b/poppler/README.md
@@ -21,5 +21,5 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 
 ## Project Websites
 
-*   https://ruby-gnome2.osdn.jp/
+*   https://ruby-gnome.github.io/
 *   https://github.com/ruby-gnome/ruby-gnome

--- a/poppler/poppler.gemspec
+++ b/poppler/poppler.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.description   = "Ruby/Poppler is a Ruby binding of poppler-glib."
   s.author        = "The Ruby-GNOME Project Team"
   s.email         = "ruby-gnome2-devel-en@lists.sourceforge.net"
-  s.homepage      = "https://ruby-gnome2.osdn.jp/"
+  s.homepage      = "https://ruby-gnome.github.io/"
   s.licenses      = ["LGPL-2.1+"]
   s.version       = ruby_glib2_version
   s.extensions    = ["dependency-check/Rakefile"]

--- a/rsvg2-no-gi/README
+++ b/rsvg2-no-gi/README
@@ -32,4 +32,4 @@ Copying
 
 Project Website
 ---------------
-   https://ruby-gnome2.osdn.jp/
+   https://ruby-gnome.github.io/

--- a/rsvg2/README.md
+++ b/rsvg2/README.md
@@ -22,5 +22,5 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 
 ## Project Websites
 
-* https://ruby-gnome2.osdn.jp/
+* https://ruby-gnome.github.io/
 * https://github.com/ruby-gnome/ruby-gnome

--- a/rsvg2/rsvg2.gemspec
+++ b/rsvg2/rsvg2.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.description   = "Ruby/RSVG2 is a Ruby binding of librsvg-2.x."
   s.author        = "The Ruby-GNOME Project Team"
   s.email         = "ruby-gnome2-devel-en@lists.sourceforge.net"
-  s.homepage      = "https://ruby-gnome2.osdn.jp/"
+  s.homepage      = "https://ruby-gnome.github.io/"
   s.licenses      = ["LGPL-2.1+"]
   s.version       = ruby_glib2_version
   s.extensions    = ["dependency-check/Rakefile"]

--- a/vte3-no-gi/README.md
+++ b/vte3-no-gi/README.md
@@ -5,7 +5,7 @@ Ruby/VTE3 is a Ruby binding of VTE for use with GTK3.
 ## Requirements
 
 * Ruby/GTK3 in
-  [Ruby-GNOME2](https://ruby-gnome2.osdn.jp/)
+  [Ruby-GNOME2](https://ruby-gnome.github.io/)
 * [VTE](https://live.gnome.org/Terminal/VTE)
 
 ## Install
@@ -21,4 +21,4 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 
 ## Project Website
 
-https://ruby-gnome2.osdn.jp/
+https://ruby-gnome.github.io/

--- a/vte3/README.md
+++ b/vte3/README.md
@@ -5,7 +5,7 @@ Ruby/VTE3 is a Ruby binding of VTE for use with GTK3.
 ## Requirements
 
 * Ruby/GTK3 in
-  [Ruby-GNOME](https://ruby-gnome2.osdn.jp/)
+  [Ruby-GNOME](https://ruby-gnome.github.io/)
 * [VTE](https://live.gnome.org/Terminal/VTE)
 
 ## Install
@@ -21,4 +21,4 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 
 ## Project Website
 
-https://ruby-gnome2.osdn.jp/
+https://ruby-gnome.github.io/

--- a/webkit-gtk/README.md
+++ b/webkit-gtk/README.md
@@ -5,7 +5,7 @@ Ruby/WebKitGTK is a Ruby binding of WebKitGTK+.
 ## Requirements
 
 * Ruby/GObjectIntrospection and Ruby/GTK3 in
-  [Ruby-GNOME2](https://ruby-gnome2.osdn.jp/)
+  [Ruby-GNOME2](https://ruby-gnome.github.io/)
 * [WebKitGTK+](http://webkitgtk.org/) 2.4.11 or later.
 
 ## Install
@@ -21,4 +21,4 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 
 ## Project Website
 
-https://ruby-gnome2.osdn.jp/
+https://ruby-gnome.github.io/

--- a/webkit-gtk/webkit-gtk.gemspec
+++ b/webkit-gtk/webkit-gtk.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.description   = "Ruby/WebKitGTK is a Ruby binding of WebKitGTK+."
   s.author        = "The Ruby-GNOME Project Team"
   s.email         = "ruby-gnome2-devel-en@lists.sourceforge.net"
-  s.homepage      = "https://ruby-gnome2.osdn.jp/"
+  s.homepage      = "https://ruby-gnome.github.io/"
   s.licenses      = ["LGPL-2.1+"]
   s.version       = ruby_glib2_version
   s.extensions    = ["dependency-check/Rakefile"]

--- a/webkit2-gtk/README.md
+++ b/webkit2-gtk/README.md
@@ -5,7 +5,7 @@ Ruby/WebKit2GTK is a Ruby binding of WebKit2GTK+.
 ## Requirements
 
 * Ruby/GObjectIntrospection and Ruby/GTK3 in
-  [Ruby-GNOME](https://ruby-gnome2.osdn.jp/)
+  [Ruby-GNOME](https://ruby-gnome.github.io/)
 * [WebKit2GTK+](http://webkitgtk.org/) 2.32.0 or later.
 
 ## Install
@@ -21,4 +21,4 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 
 ## Project Website
 
-https://ruby-gnome2.osdn.jp/
+https://ruby-gnome.github.io/

--- a/webkit2-gtk/webkit2-gtk.gemspec
+++ b/webkit2-gtk/webkit2-gtk.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.description   = "Ruby/WebKit2GTK is a Ruby binding of WebKit2GTK+."
   s.author        = "The Ruby-GNOME Project Team"
   s.email         = "ruby-gnome2-devel-en@lists.sourceforge.net"
-  s.homepage      = "https://ruby-gnome2.osdn.jp/"
+  s.homepage      = "https://ruby-gnome.github.io/"
   s.licenses      = ["LGPL-2.1+"]
   s.version       = ruby_glib2_version
   s.extensions    = ["dependency-check/Rakefile"]

--- a/wnck3/README.md
+++ b/wnck3/README.md
@@ -5,7 +5,7 @@ Ruby/WNCK3 is a Ruby binding of libwnck 3.
 ## Requirements
 
 * Ruby/GObjectIntrospection in
-  [Ruby-GNOME2](https://ruby-gnome2.osdn.jp/)
+  [Ruby-GNOME2](https://ruby-gnome.github.io/)
 * [libwnck](https://developer.gnome.org/libwnck/stable/)
 
 ## Install
@@ -21,4 +21,4 @@ under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
 
 ## Project Website
 
-https://ruby-gnome2.osdn.jp/
+https://ruby-gnome.github.io/

--- a/wnck3/wnck3.gemspec
+++ b/wnck3/wnck3.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.description   = "Ruby/WNCK3 is a Ruby binding of libwnck 3."
   s.author        = "The Ruby-GNOME Project Team"
   s.email         = "ruby-gnome2-devel-en@lists.sourceforge.net"
-  s.homepage      = "https://ruby-gnome2.osdn.jp/"
+  s.homepage      = "https://ruby-gnome.github.io/"
   s.licenses      = ["LGPL-2.1+"]
   s.version       = ruby_glib2_version
   s.extensions    = ["dependency-check/Rakefile"]


### PR DESCRIPTION
Replace "https://ruby-gnome2.osdn.jp/" with "https://ruby-gnome.github.io/" in homepage and Project Website. 

Fix https://github.com/ruby-gnome/ruby-gnome/issues/1611