### PR TITLE
gtksourceview5 sample: use gtksourceview5

### DIFF
--- a/gtksourceview5/sample/test.rb
+++ b/gtksourceview5/sample/test.rb
@@ -11,9 +11,9 @@
 require 'gtksourceview5'
 
 
-main = Gtk::Application.new("org.test.gtksourceview5")
+app = Gtk::Application.new("io.github.ruby-gnome.gtksourceview5.sample")
 
-main.signal_connect("activate") do |app|
+app.signal_connect("activate") do
   window = Gtk::ApplicationWindow.new(app)
   
   view = GtkSource::View.new
@@ -39,5 +39,5 @@ main.signal_connect("activate") do |app|
   window.present
 end
 
-main.run
+app.run
 

--- a/gtksourceview5/sample/test.rb
+++ b/gtksourceview5/sample/test.rb
@@ -14,8 +14,7 @@ require 'gtksourceview5'
 main = Gtk::Application.new("org.test.gtksourceview5")
 
 main.signal_connect("activate") do |app|
-  window = Gtk::Window.new()
-  window.application = app
+  window = Gtk::ApplicationWindow.new(app)
   
   view = GtkSource::View.new
   scrolled_window = Gtk::ScrolledWindow.new

--- a/gtksourceview5/sample/test.rb
+++ b/gtksourceview5/sample/test.rb
@@ -1,35 +1,42 @@
 #!/usr/bin/env ruby
 #
-# test.rb - Ruby/GtkSourceView4 sample script.
+# test.rb - Ruby/GtkSourceView5 sample script.
 #
-# Copyright (c) 2006-2020 Ruby-GNOME Project Team
+# Copyright (c) 2006-2024 Ruby-GNOME Project Team
 # This program is licenced under the same licence as Ruby-GNOME.
 #
 # $Id: test.rb,v 1.4 2007/06/03 02:11:07 mutoh Exp $
 
-require 'gtksourceview4'
 
-window = Gtk::Window.new
-window.signal_connect('delete-event') { Gtk.main_quit }
+require 'gtksourceview5'
 
-view = GtkSource::View.new
-window.add(Gtk::ScrolledWindow.new.add(view))
-view.show_line_numbers = true
-view.insert_spaces_instead_of_tabs = true
-view.indent_width = 2
-view.show_right_margin = true
-view.right_margin_position = 80
 
-lang = GtkSource::LanguageManager.new.get_language('ruby')
-view.buffer.language = lang
-view.buffer.highlight_syntax = true
-view.buffer.highlight_matching_brackets = true
-view.buffer.text = File.read(__FILE__)
-provider = Gtk::CssProvider.new
-provider.load(data: 'textview { font-family: Monospace; font-size: 8pt; }')
-view.style_context.add_provider(provider)
+main = Gtk::Application.new("org.test.gtksourceview5")
 
-window.set_default_size(480, 480)
-window.show_all
+main.signal_connect("activate") do |app|
+  window = Gtk::Window.new()
+  window.application = app
+  
+  view = GtkSource::View.new
+  window.set_child(Gtk::ScrolledWindow.new.set_child(view))
+  view.show_line_numbers = true
+  view.insert_spaces_instead_of_tabs = true
+  view.indent_width = 2
+  view.show_right_margin = true
+  view.right_margin_position = 80
+  
+  lang = GtkSource::LanguageManager.new.get_language('ruby')
+  view.buffer.language = lang
+  view.buffer.highlight_syntax = true
+  view.buffer.highlight_matching_brackets = true
+  view.buffer.text = File.read(__FILE__)
+  provider = Gtk::CssProvider.new
+  provider.load(data: 'textview { font-family: Monospace; font-size: 8pt; }')
+  view.style_context.add_provider(provider)
+  
+  window.set_default_size(480, 480)
+  window.present
+end
 
-Gtk.main
+main.run
+

--- a/gtksourceview5/sample/test.rb
+++ b/gtksourceview5/sample/test.rb
@@ -18,7 +18,9 @@ main.signal_connect("activate") do |app|
   window.application = app
   
   view = GtkSource::View.new
-  window.set_child(Gtk::ScrolledWindow.new.set_child(view))
+  scrolled_window = Gtk::ScrolledWindow.new
+  scrolled_window.child = view
+  window.child = scrolled_window
   view.show_line_numbers = true
   view.insert_spaces_instead_of_tabs = true
   view.indent_width = 2


### PR DESCRIPTION
This example was listed under gtksourceview5, but it used gtksourceview4.  I updated it to use gtk4/gtksourceview5.

This file should be renamed to gtksourceview5_demo.rb.  

Also, please look at my recent open issue about ColumnView, and please push the most recent gtk3 gem that has the pixbuf issue in Windows fixed.

Thanks for all your great work,
Eric