### PR TITLE
gstreamer: Add AudioLoader

### DIFF
--- a/gstreamer/lib/gst.rb
+++ b/gstreamer/lib/gst.rb
@@ -21,6 +21,7 @@ require "gobject-introspection"
 require "gst/loader"
 require "gst/base-loader"
 require "gst/controller-loader"
+require "gst/audio-loader"
 
 module Gst
   LOG_DOMAIN = "GStreamer"
@@ -55,6 +56,7 @@ module Gst
       loader.load
       init_base
       init_controller
+      init_audio
     end
 
     private
@@ -68,6 +70,12 @@ module Gst
       loader = GstController::Loader.new(GstController)
       loader.load
       Gst.include(GstController)
+    end
+
+    def init_audio
+      loader = GstAudio::Loader.new(GstAudio)
+      loader.load
+      Gst.include(GstAudio)
     end
   end
 end

--- a/gstreamer/lib/gst/audio-loader.rb
+++ b/gstreamer/lib/gst/audio-loader.rb
@@ -1,0 +1,23 @@
+# Copyright (C) 2024  Ruby-GNOME Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module GstAudio
+  class Loader < GObjectIntrospection::Loader
+    def load
+      super("GstAudio")
+    end
+  end
+end

--- a/gstreamer/test/test-audio.rb
+++ b/gstreamer/test/test-audio.rb
@@ -15,6 +15,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 class TestAudio < Test::Unit::TestCase
+  include GStreamerTestUtils
+
   def test_audio_info
     audio_info = Gst::AudioInfo.new
     audio_info.set_format(:s8, 44100, 2)
@@ -30,6 +32,8 @@ class TestAudio < Test::Unit::TestCase
   end
 
   def test_audio_info_from_caps
+    only_gstreamer_version(1, 20)
+
     caps = Gst::Caps.new("audio/ogg")
     caps.set_value("format", "S8")
     caps.set_value("rate", 44100)

--- a/gstreamer/test/test-audio.rb
+++ b/gstreamer/test/test-audio.rb
@@ -23,13 +23,13 @@ class TestAudio < Test::Unit::TestCase
 
     audio_info = Gst::AudioInfo.new(caps)
     structure = audio_info.to_caps.structures[0]
-    assert_equal(44100, structure.get_value("rate").value)
-    assert_equal(2, structure.get_value("channels").value)
+    assert_equal(44100, audio_info.rate)
+    assert_equal(2, audio_info.channels)
 
     audio_info.set_format(:f32le, 16000, 1)
     modified_structure = audio_info.to_caps.structures[0]
     assert_equal("F32LE", modified_structure.get_value("format").value)
-    assert_equal(16000, modified_structure.get_value("rate").value)
-    assert_equal(1, modified_structure.get_value("channels").value)
+    assert_equal(16000, audio_info.rate)
+    assert_equal(1, audio_info.channels)
   end
 end

--- a/gstreamer/test/test-audio.rb
+++ b/gstreamer/test/test-audio.rb
@@ -1,0 +1,36 @@
+# Copyright (C) 2024  Ruby-GNOME Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+class TestAudio < Test::Unit::TestCase
+  def test_audio
+    caps = Gst::Caps.new("audio/ogg")
+    caps.set_value("format", "S8")
+    caps.set_value("rate", 44100)
+    caps.set_value("channels", 2)
+
+    success, audio_info = Gst::AudioInfo.from_caps(caps)
+    assert(success)
+    structure = audio_info.to_caps.structures[0]
+    assert_equal(44100, structure.get_value("rate").value)
+    assert_equal(2, structure.get_value("channels").value)
+
+    audio_info.set_format(Gst::AudioFormat::F32LE, 16000, 1)
+    modified_structure = audio_info.to_caps.structures[0]
+    assert_equal("F32LE", modified_structure.get_value("format").value)
+    assert_equal(16000, modified_structure.get_value("rate").value)
+    assert_equal(1, modified_structure.get_value("channels").value)
+  end
+end

--- a/gstreamer/test/test-audio.rb
+++ b/gstreamer/test/test-audio.rb
@@ -15,7 +15,21 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 class TestAudio < Test::Unit::TestCase
-  def test_audio
+  def test_audio_info
+    audio_info = Gst::AudioInfo.new
+    audio_info.set_format(:s8, 44100, 2)
+    structure = audio_info.to_caps.structures[0]
+    assert_equal(44100, audio_info.rate)
+    assert_equal(2, audio_info.channels)
+
+    audio_info.set_format(:f32le, 16000, 1)
+    modified_structure = audio_info.to_caps.structures[0]
+    assert_equal("F32LE", modified_structure.get_value("format").value)
+    assert_equal(16000, audio_info.rate)
+    assert_equal(1, audio_info.channels)
+  end
+
+  def test_audio_info_from_caps
     caps = Gst::Caps.new("audio/ogg")
     caps.set_value("format", "S8")
     caps.set_value("rate", 44100)

--- a/gstreamer/test/test-audio.rb
+++ b/gstreamer/test/test-audio.rb
@@ -21,8 +21,7 @@ class TestAudio < Test::Unit::TestCase
     caps.set_value("rate", 44100)
     caps.set_value("channels", 2)
 
-    success, audio_info = Gst::AudioInfo.from_caps(caps)
-    assert(success)
+    audio_info = Gst::AudioInfo.new(caps)
     structure = audio_info.to_caps.structures[0]
     assert_equal(44100, structure.get_value("rate").value)
     assert_equal(2, structure.get_value("channels").value)

--- a/gstreamer/test/test-audio.rb
+++ b/gstreamer/test/test-audio.rb
@@ -27,7 +27,7 @@ class TestAudio < Test::Unit::TestCase
     assert_equal(44100, structure.get_value("rate").value)
     assert_equal(2, structure.get_value("channels").value)
 
-    audio_info.set_format(Gst::AudioFormat::F32LE, 16000, 1)
+    audio_info.set_format(:f32le, 16000, 1)
     modified_structure = audio_info.to_caps.structures[0]
     assert_equal("F32LE", modified_structure.get_value("format").value)
     assert_equal(16000, modified_structure.get_value("rate").value)


### PR DESCRIPTION
Hi,

I added `Gst::AudioLoader` to use [`GstAudioInfo`](https://gstreamer.freedesktop.org/documentation/audio/audio-info.html?gi-language=c) for #1634

Thank you.