### PR TITLE
glib2: Add support for param for `TypeInstance` based object

### DIFF
--- a/glib2/ext/glib2/rbgobj_paramspecs.c
+++ b/glib2/ext/glib2/rbgobj_paramspecs.c
@@ -264,6 +264,21 @@ object_initialize(VALUE self, VALUE name, VALUE nick, VALUE blurb,
                   VALUE object_type, VALUE flags)
 {
     GParamSpec* pspec;
+    pspec = g_param_spec_object(RVAL2CSTR(name),
+                                RVAL2CSTR_ACCEPT_NIL(nick),
+                                RVAL2CSTR_ACCEPT_NIL(blurb),
+                                rbgobj_gtype_from_ruby(object_type),
+                                resolve_flags(flags));
+    
+    rbgobj_param_spec_initialize(self, pspec);
+    return Qnil;
+}
+
+static VALUE
+typeinstance_initialize(VALUE self, VALUE name, VALUE nick, VALUE blurb,
+                  VALUE object_type, VALUE flags)
+{
+    GParamSpec* pspec;
     pspec = g_param_spec_internal(G_TYPE_PARAM_OBJECT,
                                 RVAL2CSTR(name),
                                 RVAL2CSTR_ACCEPT_NIL(nick),
@@ -356,4 +371,7 @@ Init_gobject_gparamspecs(void)
 
     c = G_DEF_CLASS(G_TYPE_PARAM_OBJECT, "Object", cParamSpec);
     rb_define_method(c, "initialize", object_initialize, 5);
+    
+    c = G_DEF_CLASS(G_TYPE_PARAM_OBJECT, "TypeInstance", cParamSpec);
+    rb_define_method(c, "initialize", typeinstance_initialize, 5);
 }


### PR DESCRIPTION
Vala uses `TypeInstance` when no parent isn't defined:

```vala
public class MyClass { // TypeInstance is used
}
```

`GLib::Param::Object.new` uses `g_param_spec_object()` internally and it validates whether the given `GType` is a `G_TYPE_OBJECT`. But `TypeInstance` based object isn't a `G_TYPE_OBJECT`. So we can't use `g_param_spec_object()` for `TypeInstance` based object that is created by Vala.

Vala uses `g_param_spec_internal(G_TYPE_PARAM_OBJECT)` for `TypeInstance` based object. So we add `GLib::Param::TypeInstance` for the case.