### PR TITLE
gstreamer: Make audio Gst::Sample export MemoryView

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ group :development, :docs, :test do
   gem "bundler"
   gem "erb"
   gem "rake"
+  gem "fiddle", ">= 1.0.9"
 end
 
 group :docs do

--- a/Gemfile
+++ b/Gemfile
@@ -26,8 +26,8 @@ end
 group :development, :docs, :test do
   gem "bundler"
   gem "erb"
-  gem "rake"
   gem "fiddle"
+  gem "rake"
 end
 
 group :docs do

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ group :development, :docs, :test do
   gem "bundler"
   gem "erb"
   gem "rake"
-  gem "fiddle", ">= 1.0.9"
+  gem "fiddle"
 end
 
 group :docs do

--- a/dockerfiles/almalinux-9.dockerfile
+++ b/dockerfiles/almalinux-9.dockerfile
@@ -11,6 +11,7 @@ RUN \
     gcc-c++ \
     git \
     gstreamer1-plugins-good \
+    libffi-devel \
     make \
     redhat-rpm-config \
     ruby-devel \
@@ -19,6 +20,10 @@ RUN \
     which \
     xorg-x11-server-Xvfb && \
   dnf clean all
+
+RUN \
+  gem install --no-user-install \
+    fiddle
 
 RUN \
   useradd --user-group --create-home ruby-gnome

--- a/dockerfiles/ubuntu-22.04.dockerfile
+++ b/dockerfiles/ubuntu-22.04.dockerfile
@@ -14,10 +14,15 @@ RUN \
     git \
     gnumeric \
     gstreamer1.0-plugins-good \
+    libffi-dev \
     make \
     ruby-dev \
     sudo \
     xvfb
+
+RUN \
+  gem install --no-user-install \
+    fiddle
 
 RUN \
   useradd --user-group --create-home ruby-gnome

--- a/gstreamer/ext/gstreamer/extconf.rb
+++ b/gstreamer/ext/gstreamer/extconf.rb
@@ -28,6 +28,7 @@ $LOAD_PATH.unshift(mkmf_gnome2_dir.to_s) if mkmf_gnome2_dir.exist?
 
 module_name = "gstreamer"
 package_id = "gstreamer-1.0"
+audio_package_id = "gstreamer-audio-1.0"
 
 require "mkmf-gnome"
 
@@ -47,6 +48,17 @@ unless required_pkg_config_package(package_id,
                                    :homebrew => "gstreamer",
                                    :macports => "gstreamer",
                                    :msys2 => "gstreamer")
+  exit(false)
+end
+
+unless required_pkg_config_package(audio_package_id,
+                                   :alt_linux => ["gst-plugins-base1.0", "libpcre2-devel"],
+                                   :alpine_linux => "gst-plugins-base-dev",
+                                   :conda => "gst-plugins-base",
+                                   :debian => "libgstreamer-plugins-base1.0-dev",
+                                   :redhat => "pkgconfig(#{audio_package_id})",
+                                   :arch_linux => "gst-plugins-base",
+                                   :msys2 => "gst-plugins-base")
   exit(false)
 end
 

--- a/gstreamer/ext/gstreamer/extconf.rb
+++ b/gstreamer/ext/gstreamer/extconf.rb
@@ -52,7 +52,7 @@ unless required_pkg_config_package(package_id,
 end
 
 unless required_pkg_config_package(audio_package_id,
-                                   :alt_linux => ["gst-plugins-base1.0", "libpcre2-devel"],
+                                   :alt_linux => ["liborc-devel", "gst-plugins1.0-devel"],
                                    :alpine_linux => "gst-plugins-base-dev",
                                    :conda => "gst-plugins-base",
                                    :debian => "libgstreamer-plugins-base1.0-dev",

--- a/gstreamer/ext/gstreamer/extconf.rb
+++ b/gstreamer/ext/gstreamer/extconf.rb
@@ -52,7 +52,7 @@ unless required_pkg_config_package(package_id,
 end
 
 unless required_pkg_config_package(audio_package_id,
-                                   :alt_linux => ["liborc-devel", "gst-plugins1.0-devel"],
+                                   :alt_linux => ["gst-plugins1.0-devel", "liborc-devel"],
                                    :alpine_linux => "gst-plugins-base-dev",
                                    :conda => "gst-plugins-base",
                                    :debian => "libgstreamer-plugins-base1.0-dev",

--- a/gstreamer/ext/gstreamer/extconf.rb
+++ b/gstreamer/ext/gstreamer/extconf.rb
@@ -46,7 +46,7 @@ unless required_pkg_config_package(package_id,
                                    :redhat => "pkgconfig(#{package_id})",
                                    :arch_linux => "gstreamer",
                                    :homebrew => "gstreamer",
-                                   :macports => "gstreamer",
+                                   :macports => "gstreamer1",
                                    :msys2 => "gstreamer")
   exit(false)
 end
@@ -58,6 +58,7 @@ unless required_pkg_config_package(audio_package_id,
                                    :debian => "libgstreamer-plugins-base1.0-dev",
                                    :redhat => "pkgconfig(#{audio_package_id})",
                                    :arch_linux => "gst-plugins-base",
+                                   :macports => "gstreamer1-gst-plugins-base",
                                    :msys2 => "gst-plugins-base")
   exit(false)
 end

--- a/gstreamer/ext/gstreamer/rbgst-sample.c
+++ b/gstreamer/ext/gstreamer/rbgst-sample.c
@@ -320,7 +320,6 @@ rg_gst_sample_get(VALUE obj, rb_memory_view_t *view, int flags)
         gst_sample_ref(sample);
         return true;
     }
-    rb_warn("Gst::Sample: currently, only audio is supported");
 
     return false;
 }

--- a/gstreamer/ext/gstreamer/rbgst-sample.c
+++ b/gstreamer/ext/gstreamer/rbgst-sample.c
@@ -296,7 +296,7 @@ rg_gst_memory_view_init_from_audio(VALUE obj, rb_memory_view_t *view, int flags,
     private_data->buffer = buffer;
     private_data->map_info = map_info;
 #if RUBY_API_VERSION_MAJOR == 3 && RUBY_API_VERSION_MINOR == 0
-    view->private = (void *const)private_data;
+    *((void **)&view->private) = private_data;
 #else
     view->private_data = (void *)private_data;
 #endif

--- a/gstreamer/ext/gstreamer/rbgst-sample.c
+++ b/gstreamer/ext/gstreamer/rbgst-sample.c
@@ -55,6 +55,7 @@ rg_gst_memory_view_init_from_audio(VALUE obj, rb_memory_view_t *view, int flags,
     GstAudioInfo *audio_info;
     GstMapInfo *map_info;
     gboolean is_column_major_requested;
+    gboolean is_writable_requested;
     gboolean is_writable;
     gboolean is_interleaved;
     ssize_t *shape;
@@ -108,8 +109,9 @@ rg_gst_memory_view_init_from_audio(VALUE obj, rb_memory_view_t *view, int flags,
         buffer = gst_buffer_ref(buffer);
     }
 
+    is_writable_requested = flags & RUBY_MEMORY_VIEW_WRITABLE;
     is_writable = gst_sample_is_writable(sample);
-    if (!is_writable && (flags & RUBY_MEMORY_VIEW_WRITABLE)) {
+    if (is_writable_requested && !is_writable) {
         rb_warn("Gst::Sample: sample is not writable but writable memory view is requested");
         gst_audio_info_free(audio_info);
         gst_buffer_unref(buffer);
@@ -117,7 +119,7 @@ rg_gst_memory_view_init_from_audio(VALUE obj, rb_memory_view_t *view, int flags,
         return false;
     }
     map_info = ALLOC(GstMapInfo);
-    if (!gst_buffer_map(buffer, map_info, is_writable ? GST_MAP_WRITE : GST_MAP_READ)) {
+    if (!gst_buffer_map(buffer, map_info, is_writable_requested ? GST_MAP_WRITE : GST_MAP_READ)) {
         rb_warn("Gst::Sample: failed to map buffer");
         xfree(map_info);
         gst_audio_info_free(audio_info);
@@ -131,7 +133,7 @@ rg_gst_memory_view_init_from_audio(VALUE obj, rb_memory_view_t *view, int flags,
     view->obj = obj;
     view->byte_size = map_info->size;
     view->item_size = audio_info->finfo->width / 8;
-    view->readonly = !is_writable;
+    view->readonly = !is_writable_requested;
     view->ndim = 2;
     view->sub_offsets = NULL;
 

--- a/gstreamer/ext/gstreamer/rbgst-sample.c
+++ b/gstreamer/ext/gstreamer/rbgst-sample.c
@@ -316,7 +316,7 @@ rg_gst_sample_get(VALUE obj, rb_memory_view_t *view, int flags)
 
     gst_sample_unref(sample);
 
-    rb_warn("Gst::Sample: Currently, only audio is supported");
+    rb_warn("Gst::Sample: currently, only audio is supported");
 
     return false;
 }

--- a/gstreamer/ext/gstreamer/rbgst-sample.c
+++ b/gstreamer/ext/gstreamer/rbgst-sample.c
@@ -20,6 +20,7 @@
 
 #include <ruby.h>
 #include <ruby/memory_view.h>
+#include <gst/gstversion.h>
 #include <gst/audio/audio.h>
 #include "rbgst.h"
 
@@ -251,6 +252,7 @@ rg_gst_memory_view_init_from_audio(VALUE obj, rb_memory_view_t *view, int flags,
             rb_warn("Gst::Sample: only environment double or float size is 8 bytes is supported");
         }
         break;
+#if GST_CHECK_VERSION(1, 28, 0)
     case GST_AUDIO_FORMAT_S20_32LE:
         rb_warn("Gst::Sample: S20_32LE format is not supported");
         break;
@@ -263,6 +265,7 @@ rg_gst_memory_view_init_from_audio(VALUE obj, rb_memory_view_t *view, int flags,
     case GST_AUDIO_FORMAT_U20_32BE:
         rb_warn("Gst::Sample: U20_32BE format is not supported");
         break;
+#endif
     }
 
     if (view->format == NULL) {

--- a/gstreamer/ext/gstreamer/rbgst-sample.c
+++ b/gstreamer/ext/gstreamer/rbgst-sample.c
@@ -132,7 +132,8 @@ rg_gst_memory_view_init_from_audio(VALUE obj, rb_memory_view_t *view, int flags,
 
     view->obj = obj;
     view->byte_size = map_info->size;
-    view->item_size = audio_info->finfo->width / 8;
+    width = audio_info->finfo->width / 8;
+    view->item_size = width;
     view->readonly = !is_writable_requested;
     view->ndim = 2;
     view->sub_offsets = NULL;
@@ -280,8 +281,7 @@ rg_gst_memory_view_init_from_audio(VALUE obj, rb_memory_view_t *view, int flags,
         return false;
     }
 
-    n_samples = map_info->size / (audio_info->finfo->width / 8) / audio_info->channels;
-    width = audio_info->finfo->width / 8;
+    n_samples = map_info->size / width / audio_info->channels;
     shape = ALLOC_N(ssize_t, 2);
     strides = ALLOC_N(ssize_t, 2);
     // Currently, interleaved and row-major audio is supported

--- a/gstreamer/ext/gstreamer/rbgst-sample.c
+++ b/gstreamer/ext/gstreamer/rbgst-sample.c
@@ -305,16 +305,13 @@ rg_gst_sample_get(VALUE obj, rb_memory_view_t *view, int flags)
     GstCaps *caps;
 
     sample = GST_SAMPLE(RVAL2GOBJ(obj));
-    gst_sample_ref(sample);
 
     caps = gst_sample_get_caps(sample);
 
     if (rg_gst_memory_view_init_from_audio(obj, view, flags, sample, caps)) {
+        gst_sample_ref(sample);
         return true;
     }
-
-    gst_sample_unref(sample);
-
     rb_warn("Gst::Sample: currently, only audio is supported");
 
     return false;

--- a/gstreamer/ext/gstreamer/rbgst-sample.c
+++ b/gstreamer/ext/gstreamer/rbgst-sample.c
@@ -19,6 +19,7 @@
  */
 
 #include <ruby.h>
+#include <ruby/version.h>
 #include <ruby/memory_view.h>
 #include <gst/gstversion.h>
 #include <gst/audio/audio.h>
@@ -291,7 +292,11 @@ rg_gst_memory_view_init_from_audio(VALUE obj, rb_memory_view_t *view, int flags,
     private_data = ALLOC(memview_private_data);
     private_data->buffer = buffer;
     private_data->map_info = map_info;
+#if RUBY_API_VERSION_MAJOR == 3 && RUBY_API_VERSION_MINOR == 0
+    view->private = (void *const)private_data;
+#else
     view->private_data = (void *)private_data;
+#endif
 
     gst_audio_info_free(audio_info);
 
@@ -325,7 +330,11 @@ rg_gst_sample_release(VALUE obj, rb_memory_view_t *view)
 
     xfree((void *)view->shape);
     xfree((void *)view->strides);
+#if RUBY_API_VERSION_MAJOR == 3 && RUBY_API_VERSION_MINOR == 0
+    private_data = (memview_private_data *)view->private;
+#else
     private_data = (memview_private_data *)view->private_data;
+#endif
     gst_buffer_unmap(private_data->buffer, private_data->map_info);
     gst_buffer_unref(private_data->buffer);
     xfree(private_data->map_info);

--- a/gstreamer/ext/gstreamer/rbgst-sample.c
+++ b/gstreamer/ext/gstreamer/rbgst-sample.c
@@ -360,7 +360,7 @@ rg_gst_sample_available_p(VALUE obj)
     name = gst_caps_to_string(caps);
     is_supported_caps = rg_gst_is_supported_caps(name);
     if (!is_supported_caps) {
-        rb_warn("Gst::Sample: currently audio/x-raw caps only suppoted but is %s", name);
+        rb_warn("Gst::Sample: currently audio/x-raw caps only supported but is %s", name);
     }
 
     g_free(name);

--- a/gstreamer/ext/gstreamer/rbgst-sample.c
+++ b/gstreamer/ext/gstreamer/rbgst-sample.c
@@ -70,9 +70,8 @@ rg_gst_memory_view_init_from_audio(VALUE obj, rb_memory_view_t *view, int flags,
         return false;
     }
 
-    audio_info = gst_audio_info_new();
-    if (!gst_audio_info_from_caps(audio_info, caps)) {
-        gst_audio_info_free(audio_info);
+    audio_info = gst_audio_info_new_from_caps(caps);
+    if (!audio_info) {
         rb_warn("Gst::Sample: failed to get audio info");
 
         return false;

--- a/gstreamer/ext/gstreamer/rbgst-sample.c
+++ b/gstreamer/ext/gstreamer/rbgst-sample.c
@@ -1,0 +1,384 @@
+/* -*- c-file-style: "ruby"; indent-tabs-mode: nil -*- */
+/*
+ *  Copyright (C) 2025  Ruby-GNOME2 Project Team
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ *  MA  02110-1301  USA
+ */
+
+#include <ruby.h>
+#include <ruby/memory_view.h>
+#include <gst/audio/audio.h>
+#include "rbgst.h"
+
+typedef struct memview_private_data {
+    GstBuffer *buffer;
+    GstMapInfo *map_info;
+} memview_private_data;
+
+static gboolean
+rg_gst_combine_buffer_list(GstBuffer **buffer, guint idx, gpointer user_data)
+{
+    GstBuffer **acc;
+
+    acc = (GstBuffer **)user_data;
+    *acc = gst_buffer_append(*acc, gst_buffer_ref(*buffer));
+
+    return TRUE;
+}
+
+static gboolean
+rg_gst_is_supported_caps(const gchar *name)
+{
+    return g_str_has_prefix(name, "audio/x-raw");
+}
+
+static bool
+rg_gst_memory_view_init_from_audio(VALUE obj, rb_memory_view_t *view, int flags, GstSample *sample, GstCaps *caps)
+{
+    GstBuffer *buffer;
+    GstBufferList *buffer_list;
+    GstAudioInfo *audio_info;
+    GstMapInfo *map_info;
+    gboolean is_column_major_requested;
+    gboolean is_writable;
+    gboolean is_interleaved;
+    ssize_t *shape;
+    ssize_t *strides;
+    gint width;
+    gsize n_samples;
+    memview_private_data *private_data;
+
+    is_column_major_requested = flags & RUBY_MEMORY_VIEW_COLUMN_MAJOR;
+    if (is_column_major_requested) {
+        // TODO: column-major support
+        rb_warn("Gst::Sample: currently column-major is not supported");
+
+        return false;
+    }
+
+    audio_info = gst_audio_info_new();
+    if (!gst_audio_info_from_caps(audio_info, caps)) {
+        gst_audio_info_free(audio_info);
+        rb_warn("Gst::Sample: failed to get audio info");
+
+        return false;
+    }
+    if (!audio_info->finfo) {
+        gst_audio_info_free(audio_info);
+        rb_warn("Gst::Sample: failed to retrieve audio format info");
+
+        return false;
+    }
+
+    is_interleaved = audio_info->layout == GST_AUDIO_LAYOUT_INTERLEAVED;
+    if (!is_interleaved) {
+        // TODO: non-interleaved layout support
+        gst_audio_info_free(audio_info);
+        rb_warn("Gst::Sample: currently only interleaved layout is supported");
+
+        return false;
+    }
+
+    buffer_list = gst_sample_get_buffer_list(sample);
+    if (buffer_list) {
+        buffer = gst_buffer_new();
+        gst_buffer_list_foreach(buffer_list, rg_gst_combine_buffer_list, &buffer);
+    } else {
+        buffer = gst_sample_get_buffer(sample);
+        if (!buffer) {
+            gst_audio_info_free(audio_info);
+            rb_warn("Gst::Sample: failed to get buffer");
+
+            return false;
+        }
+        buffer = gst_buffer_ref(buffer);
+    }
+
+    is_writable = gst_sample_is_writable(sample);
+    if (!is_writable && (flags & RUBY_MEMORY_VIEW_WRITABLE)) {
+        rb_warn("Gst::Sample: sample is not writable but writable memory view is requested");
+        gst_audio_info_free(audio_info);
+        gst_buffer_unref(buffer);
+
+        return false;
+    }
+    map_info = ALLOC(GstMapInfo);
+    if (!gst_buffer_map(buffer, map_info, is_writable ? GST_MAP_WRITE : GST_MAP_READ)) {
+        rb_warn("Gst::Sample: failed to map buffer");
+        xfree(map_info);
+        gst_audio_info_free(audio_info);
+        gst_buffer_unref(buffer);
+
+        return false;
+    }
+
+    view->data = map_info->data;
+
+    view->obj = obj;
+    view->byte_size = map_info->size;
+    view->item_size = audio_info->finfo->width / 8;
+    view->readonly = !is_writable;
+    view->ndim = 2;
+
+    view->format = NULL;
+    switch (audio_info->finfo->format) {
+    case GST_AUDIO_FORMAT_UNKNOWN:
+        rb_warn("Gst::Sample: format is unknown");
+        break;
+    case GST_AUDIO_FORMAT_ENCODED:
+        rb_warn("Gst::Sample: encoded format is not supported");
+        break;
+    case GST_AUDIO_FORMAT_S8:
+        view->format = "c";
+        break;
+    case GST_AUDIO_FORMAT_U8:
+        view->format = "C";
+        break;
+    case GST_AUDIO_FORMAT_S16LE:
+        view->format = "s<";
+        break;
+    case GST_AUDIO_FORMAT_S16BE:
+        view->format = "s>";
+        break;
+    case GST_AUDIO_FORMAT_U16LE:
+        view->format = "v";
+        break;
+    case GST_AUDIO_FORMAT_U16BE:
+        view->format = "n";
+        break;
+    case GST_AUDIO_FORMAT_S24_32LE:
+        rb_warn("Gst::Sample: S24_32LE format is not supported");
+        break;
+    case GST_AUDIO_FORMAT_S24_32BE:
+        rb_warn("Gst::Sample: S24_32BE format is not supported");
+        break;
+    case GST_AUDIO_FORMAT_U24_32LE:
+        rb_warn("Gst::Sample: U24_32LE format is not supported");
+        break;
+    case GST_AUDIO_FORMAT_U24_32BE:
+        rb_warn("Gst::Sample: U24_32BE format is not supported");
+        break;
+    case GST_AUDIO_FORMAT_S32LE:
+        view->format = "l<";
+        break;
+    case GST_AUDIO_FORMAT_S32BE:
+        view->format = "l>";
+        break;
+    case GST_AUDIO_FORMAT_U32LE:
+        view->format = "V";
+        break;
+    case GST_AUDIO_FORMAT_U32BE:
+        view->format = "N";
+        break;
+    case GST_AUDIO_FORMAT_S24LE:
+        rb_warn("Gst::Sample: S24LE format is not supported");
+        break;
+    case GST_AUDIO_FORMAT_S24BE:
+        rb_warn("Gst::Sample: S24BE format is not supported");
+        break;
+    case GST_AUDIO_FORMAT_U24LE:
+        rb_warn("Gst::Sample: U24LE format is not supported");
+        break;
+    case GST_AUDIO_FORMAT_U24BE:
+        rb_warn("Gst::Sample: U24BE format is not supported");
+        break;
+    case GST_AUDIO_FORMAT_S20LE:
+        rb_warn("Gst::Sample: S20LE format is not supported");
+        break;
+    case GST_AUDIO_FORMAT_S20BE:
+        rb_warn("Gst::Sample: S20BE format is not supported");
+        break;
+    case GST_AUDIO_FORMAT_U20LE:
+        rb_warn("Gst::Sample: U20LE format is not supported");
+        break;
+    case GST_AUDIO_FORMAT_U20BE:
+        rb_warn("Gst::Sample: U20BE format is not supported");
+        break;
+    case GST_AUDIO_FORMAT_S18LE:
+        rb_warn("Gst::Sample: S18LE format is not supported");
+        break;
+    case GST_AUDIO_FORMAT_S18BE:
+        rb_warn("Gst::Sample: S18BE format is not supported");
+        break;
+    case GST_AUDIO_FORMAT_U18LE:
+        rb_warn("Gst::Sample: U18LE format is not supported");
+        break;
+    case GST_AUDIO_FORMAT_U18BE:
+        rb_warn("Gst::Sample: U18BE format is not supported");
+        break;
+    case GST_AUDIO_FORMAT_F32LE:
+        if (rb_memory_view_item_size_from_format("e", NULL) == 4) {
+            view->format = "e";
+        } else {
+            rb_warn("Gst::Sample: only environment float size is 4 bytes is supported");
+        }
+        break;
+    case GST_AUDIO_FORMAT_F32BE:
+        if (rb_memory_view_item_size_from_format("g", NULL) == 4) {
+            view->format = "g";
+        } else {
+            rb_warn("Gst::Sample: only environment float size is 4 bytes is supported");
+        }
+        break;
+    case GST_AUDIO_FORMAT_F64LE:
+        if (rb_memory_view_item_size_from_format("E", NULL) == 8) {
+            view->format = "E";
+        } else if (rb_memory_view_item_size_from_format("e", NULL) == 8) {
+            view->format = "e";
+        } else {
+            rb_warn("Gst::Sample: only environment double or float size is 8 bytes is supported");
+        }
+        break;
+    case GST_AUDIO_FORMAT_F64BE:
+        if (rb_memory_view_item_size_from_format("G", NULL) == 8) {
+            view->format = "G";
+        } else if (rb_memory_view_item_size_from_format("g", NULL) == 8) {
+            view->format = "g";
+        } else {
+            rb_warn("Gst::Sample: only environment double or float size is 8 bytes is supported");
+        }
+        break;
+    case GST_AUDIO_FORMAT_S20_32LE:
+        rb_warn("Gst::Sample: S20_32LE format is not supported");
+        break;
+    case GST_AUDIO_FORMAT_S20_32BE:
+        rb_warn("Gst::Sample: S20_32BE format is not supported");
+        break;
+    case GST_AUDIO_FORMAT_U20_32LE:
+        rb_warn("Gst::Sample: U20_32LE format is not supported");
+        break;
+    case GST_AUDIO_FORMAT_U20_32BE:
+        rb_warn("Gst::Sample: U20_32BE format is not supported");
+        break;
+    }
+
+    if (view->format == NULL) {
+        gst_buffer_unmap(buffer, map_info);
+        xfree(map_info);
+        gst_buffer_unref(buffer);
+        gst_audio_info_free(audio_info);
+
+        return false;
+    }
+
+    n_samples = map_info->size / (audio_info->finfo->width / 8) / audio_info->channels;
+    width = audio_info->finfo->width / 8;
+    shape = ALLOC_N(ssize_t, 2);
+    strides = ALLOC_N(ssize_t, 2);
+    // Currently, interleaved and row-major audio is supported
+    shape[0] = n_samples;
+    shape[1] = audio_info->channels;
+    strides[0] = width * audio_info->channels;
+    strides[1] = width;
+    view->shape = shape;
+    view->strides = strides;
+
+    private_data = ALLOC(memview_private_data);
+    private_data->buffer = buffer;
+    private_data->map_info = map_info;
+    view->private_data = (void *const)private_data;
+
+    gst_audio_info_free(audio_info);
+
+    return true;
+}
+
+static bool
+rg_gst_sample_get(VALUE obj, rb_memory_view_t *view, int flags)
+{
+    GstSample *sample;
+    GstCaps *caps;
+
+    sample = GST_SAMPLE(RVAL2GOBJ(obj));
+    gst_sample_ref(sample);
+
+    caps = gst_sample_get_caps(sample);
+
+    if (rg_gst_memory_view_init_from_audio(obj, view, flags, sample, caps)) {
+        return true;
+    }
+
+    gst_sample_unref(sample);
+
+    rb_warn("Gst::Sample: Currently, only audio is supported");
+
+    return false;
+}
+
+static bool
+rg_gst_sample_release(VALUE obj, rb_memory_view_t *view)
+{
+    GstSample *sample;
+    memview_private_data *private_data;
+
+    xfree((void *)view->shape);
+    xfree((void *)view->strides);
+    private_data = (memview_private_data *)view->private_data;
+    gst_buffer_unmap(private_data->buffer, private_data->map_info);
+    gst_buffer_unref(private_data->buffer);
+    xfree(private_data->map_info);
+    xfree(private_data);
+    sample = GST_SAMPLE(RVAL2GOBJ(obj));
+    gst_sample_unref(sample);
+
+    return true;
+}
+
+static bool
+rg_gst_sample_available_p(VALUE obj)
+{
+    GstSample *sample;
+    GstCaps *caps;
+    gchar *name;
+    gboolean is_supported_caps;
+
+    sample = GST_SAMPLE(RVAL2GOBJ(obj));
+
+    caps = gst_sample_get_caps(sample);
+    if (!caps) {
+        return false;
+    }
+    if (gst_caps_get_size(caps) != 1) {
+        return false;
+    }
+
+    name = gst_caps_to_string(caps);
+    is_supported_caps = rg_gst_is_supported_caps(name);
+    if (!is_supported_caps) {
+        rb_warn("Gst::Sample: currently audio/x-raw caps only suppoted but is %s", name);
+    }
+
+    g_free(name);
+
+    return is_supported_caps;
+}
+
+static rb_memory_view_entry_t rg_gst_sample_entry = {
+    rg_gst_sample_get,
+    rg_gst_sample_release,
+    rg_gst_sample_available_p,
+};
+
+void
+rb_gst_init_sample(void)
+{
+    VALUE mGst;
+    VALUE cSample;
+
+    mGst = rb_const_get(rb_cObject, rb_intern("Gst"));
+    cSample = rb_const_get(mGst, rb_intern("Sample"));
+    rb_memory_view_register(cSample, &rg_gst_sample_entry);
+}

--- a/gstreamer/ext/gstreamer/rbgst-sample.c
+++ b/gstreamer/ext/gstreamer/rbgst-sample.c
@@ -54,10 +54,10 @@ rg_gst_memory_view_init_from_audio(VALUE obj, rb_memory_view_t *view, int flags,
     GstBufferList *buffer_list;
     GstAudioInfo *audio_info;
     GstMapInfo *map_info;
-    gboolean is_column_major_requested;
-    gboolean is_writable_requested;
+    bool is_column_major_requested;
+    bool is_writable_requested;
     gboolean is_writable;
-    gboolean is_interleaved;
+    bool is_interleaved;
     ssize_t *shape;
     ssize_t *strides;
     gint width;

--- a/gstreamer/ext/gstreamer/rbgst-sample.c
+++ b/gstreamer/ext/gstreamer/rbgst-sample.c
@@ -54,7 +54,6 @@ rg_gst_memory_view_init_from_audio(VALUE obj, rb_memory_view_t *view, int flags,
     GstBufferList *buffer_list;
     GstAudioInfo *audio_info;
     GstMapInfo *map_info;
-    bool is_column_major_requested;
     bool is_writable_requested;
     gboolean is_writable;
     bool is_interleaved;
@@ -63,14 +62,6 @@ rg_gst_memory_view_init_from_audio(VALUE obj, rb_memory_view_t *view, int flags,
     gint width;
     gsize n_samples;
     memview_private_data *private_data;
-
-    is_column_major_requested = flags & RUBY_MEMORY_VIEW_COLUMN_MAJOR;
-    if (is_column_major_requested) {
-        // TODO: column-major support
-        rb_warn("Gst::Sample: currently column-major is not supported");
-
-        return false;
-    }
 
     audio_info = gst_audio_info_new_from_caps(caps);
     if (!audio_info) {
@@ -311,6 +302,15 @@ rg_gst_sample_get(VALUE obj, rb_memory_view_t *view, int flags)
 {
     GstSample *sample;
     GstCaps *caps;
+    bool is_column_major_requested;
+
+    is_column_major_requested = flags & RUBY_MEMORY_VIEW_COLUMN_MAJOR;
+    if (is_column_major_requested) {
+        // TODO: column-major support
+        rb_warn("Gst::Sample: currently column-major is not supported");
+
+        return false;
+    }
 
     sample = GST_SAMPLE(RVAL2GOBJ(obj));
 

--- a/gstreamer/ext/gstreamer/rbgst-sample.c
+++ b/gstreamer/ext/gstreamer/rbgst-sample.c
@@ -133,6 +133,7 @@ rg_gst_memory_view_init_from_audio(VALUE obj, rb_memory_view_t *view, int flags,
     view->item_size = audio_info->finfo->width / 8;
     view->readonly = !is_writable;
     view->ndim = 2;
+    view->sub_offsets = NULL;
 
     view->format = NULL;
     switch (audio_info->finfo->format) {

--- a/gstreamer/ext/gstreamer/rbgst-sample.c
+++ b/gstreamer/ext/gstreamer/rbgst-sample.c
@@ -154,10 +154,10 @@ rg_gst_memory_view_init_from_audio(VALUE obj, rb_memory_view_t *view, int flags,
         view->format = "s>";
         break;
     case GST_AUDIO_FORMAT_U16LE:
-        view->format = "v";
+        view->format = "S<";
         break;
     case GST_AUDIO_FORMAT_U16BE:
-        view->format = "n";
+        view->format = "S>";
         break;
     case GST_AUDIO_FORMAT_S24_32LE:
         rb_warn("Gst::Sample: S24_32LE format is not supported");
@@ -178,10 +178,10 @@ rg_gst_memory_view_init_from_audio(VALUE obj, rb_memory_view_t *view, int flags,
         view->format = "l>";
         break;
     case GST_AUDIO_FORMAT_U32LE:
-        view->format = "V";
+        view->format = "L<";
         break;
     case GST_AUDIO_FORMAT_U32BE:
-        view->format = "N";
+        view->format = "L>";
         break;
     case GST_AUDIO_FORMAT_S24LE:
         rb_warn("Gst::Sample: S24LE format is not supported");

--- a/gstreamer/ext/gstreamer/rbgst-sample.c
+++ b/gstreamer/ext/gstreamer/rbgst-sample.c
@@ -267,7 +267,7 @@ rg_gst_memory_view_init_from_audio(VALUE obj, rb_memory_view_t *view, int flags,
 #endif
     }
 
-    if (view->format == NULL) {
+    if (!view->format) {
         gst_buffer_unmap(buffer, map_info);
         xfree(map_info);
         gst_buffer_unref(buffer);

--- a/gstreamer/ext/gstreamer/rbgst-sample.c
+++ b/gstreamer/ext/gstreamer/rbgst-sample.c
@@ -1,6 +1,6 @@
 /* -*- c-file-style: "ruby"; indent-tabs-mode: nil -*- */
 /*
- *  Copyright (C) 2025  Ruby-GNOME2 Project Team
+ *  Copyright (C) 2026  Ruby-GNOME Project Team
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public

--- a/gstreamer/ext/gstreamer/rbgst-sample.c
+++ b/gstreamer/ext/gstreamer/rbgst-sample.c
@@ -291,7 +291,7 @@ rg_gst_memory_view_init_from_audio(VALUE obj, rb_memory_view_t *view, int flags,
     private_data = ALLOC(memview_private_data);
     private_data->buffer = buffer;
     private_data->map_info = map_info;
-    view->private_data = (void *const)private_data;
+    view->private_data = (void *)private_data;
 
     gst_audio_info_free(audio_info);
 

--- a/gstreamer/ext/gstreamer/rbgst-sample.c
+++ b/gstreamer/ext/gstreamer/rbgst-sample.c
@@ -85,10 +85,18 @@ rg_gst_memory_view_init_from_audio(VALUE obj, rb_memory_view_t *view, int flags,
         return false;
     }
 
+    is_writable_requested = flags & RUBY_MEMORY_VIEW_WRITABLE;
+
     buffer_list = gst_sample_get_buffer_list(sample);
     if (buffer_list) {
-        buffer = gst_buffer_new();
-        gst_buffer_list_foreach(buffer_list, rg_gst_combine_buffer_list, &buffer);
+      if (is_writable_requested) {
+          gst_audio_info_free(audio_info);
+          rb_warn("Gst::Sample: currently writable buffer list is not supported");
+
+          return false;
+      }
+      buffer = gst_buffer_new();
+      gst_buffer_list_foreach(buffer_list, rg_gst_combine_buffer_list, &buffer);
     } else {
         buffer = gst_sample_get_buffer(sample);
         if (!buffer) {
@@ -100,7 +108,6 @@ rg_gst_memory_view_init_from_audio(VALUE obj, rb_memory_view_t *view, int flags,
         buffer = gst_buffer_ref(buffer);
     }
 
-    is_writable_requested = flags & RUBY_MEMORY_VIEW_WRITABLE;
     is_writable = gst_sample_is_writable(sample);
     if (is_writable_requested && !is_writable) {
         rb_warn("Gst::Sample: sample is not writable but writable memory view is requested");

--- a/gstreamer/ext/gstreamer/rbgst-sample.c
+++ b/gstreamer/ext/gstreamer/rbgst-sample.c
@@ -279,6 +279,15 @@ rg_gst_memory_view_init_from_audio(VALUE obj, rb_memory_view_t *view, int flags,
         return false;
     }
 
+    if (map_info->size % (width * audio_info->channels) != 0) {
+        rb_warn("Gst::Sample: buffer size is not aligned with sample width and channels");
+        gst_buffer_unmap(buffer, map_info);
+        xfree(map_info);
+        gst_buffer_unref(buffer);
+        gst_audio_info_free(audio_info);
+
+        return false;
+    }
     n_samples = map_info->size / width / audio_info->channels;
     shape = ALLOC_N(ssize_t, 2);
     strides = ALLOC_N(ssize_t, 2);

--- a/gstreamer/ext/gstreamer/rbgst-sample.c
+++ b/gstreamer/ext/gstreamer/rbgst-sample.c
@@ -385,10 +385,12 @@ static rb_memory_view_entry_t rg_gst_sample_entry = {
 void
 rb_gst_init_sample(void)
 {
+#if GST_CHECK_VERSION(1, 20, 0)
     VALUE mGst;
     VALUE cSample;
 
     mGst = rb_const_get(rb_cObject, rb_intern("Gst"));
     cSample = rb_const_get(mGst, rb_intern("Sample"));
     rb_memory_view_register(cSample, &rg_gst_sample_entry);
+#endif
 }

--- a/gstreamer/ext/gstreamer/rbgst.c
+++ b/gstreamer/ext/gstreamer/rbgst.c
@@ -72,4 +72,5 @@ Init_gstreamer (void)
 
     rb_gst_init_child_proxy();
     rb_gst_init_element();
+    rb_gst_init_sample();
 }

--- a/gstreamer/ext/gstreamer/rbgst.h
+++ b/gstreamer/ext/gstreamer/rbgst.h
@@ -25,3 +25,4 @@
 extern void Init_gstreamer (void);
 G_GNUC_INTERNAL extern void rb_gst_init_child_proxy (void);
 G_GNUC_INTERNAL extern void rb_gst_init_element (void);
+G_GNUC_INTERNAL extern void rb_gst_init_sample (void);

--- a/gstreamer/gstreamer.gemspec
+++ b/gstreamer/gstreamer.gemspec
@@ -44,18 +44,31 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency("gobject-introspection", "= #{s.version}")
 
-  [
-    ["alpine_linux", "gstreamer-dev"],
-    ["alt_linux", "gstreamer1.0-devel"],
-    ["arch_linux", "gstreamer"],
-    ["conda", "gstreamer"],
-    ["debian", "libgstreamer1.0-dev"],
-    ["homebrew", "gstreamer"],
-    ["macports", "gstreamer"],
-    ["msys2", "gstreamer"],
-    ["rhel", "pkgconfig(gstreamer-1.0)"],
-  ].each do |platform, package|
-    s.requirements << "system: gstreamer-1.0: #{platform}: #{package}"
+  {
+    "gstreamer-1.0" => [
+      ["alpine_linux", "gstreamer-dev"],
+      ["alt_linux", "gstreamer1.0-devel"],
+      ["arch_linux", "gstreamer"],
+      ["conda", "gstreamer"],
+      ["debian", "libgstreamer1.0-dev"],
+      ["homebrew", "gstreamer"],
+      ["macports", "gstreamer"],
+      ["msys2", "gstreamer"],
+      ["rhel", "pkgconfig(gstreamer-1.0)"]
+    ],
+    "gstreamer-audio-1.0" => [
+      ["alpine_linux", "gst-plugins-base-dev"],
+      ["alt_linux", "gst-plugins-base1.0"],
+      ["arch_linux", "gst-plugins-base"],
+      ["conda", "gst-plugins-base"],
+      ["debian", "libgstreamer-plugins-base1.0-dev"],
+      ["msys2", "gst-plugins-base"],
+      ["rhel", "pkgconfig(gstreamer-audio-1.0)"]
+    ]
+  }.each_pair do |id, requirements|
+    requirements.each do |platform, package|
+      s.requirements << "system: #{id}: #{platform}: #{package}"
+    end
   end
 
   s.metadata["msys2_mingw_dependencies"] = "gstreamer"

--- a/gstreamer/gstreamer.gemspec
+++ b/gstreamer/gstreamer.gemspec
@@ -58,7 +58,8 @@ Gem::Specification.new do |s|
     ],
     "gstreamer-audio-1.0" => [
       ["alpine_linux", "gst-plugins-base-dev"],
-      ["alt_linux", "gst-plugins-base1.0"],
+      ["alt_linux", "liborc-devel"],
+      ["alt_linux", "gst-plugins1.0-devel"],
       ["arch_linux", "gst-plugins-base"],
       ["conda", "gst-plugins-base"],
       ["debian", "libgstreamer-plugins-base1.0-dev"],

--- a/gstreamer/gstreamer.gemspec
+++ b/gstreamer/gstreamer.gemspec
@@ -58,8 +58,8 @@ Gem::Specification.new do |s|
     ],
     "gstreamer-audio-1.0" => [
       ["alpine_linux", "gst-plugins-base-dev"],
-      ["alt_linux", "liborc-devel"],
       ["alt_linux", "gst-plugins1.0-devel"],
+      ["alt_linux", "liborc-devel"],
       ["arch_linux", "gst-plugins-base"],
       ["conda", "gst-plugins-base"],
       ["debian", "libgstreamer-plugins-base1.0-dev"],

--- a/gstreamer/gstreamer.gemspec
+++ b/gstreamer/gstreamer.gemspec
@@ -52,7 +52,7 @@ Gem::Specification.new do |s|
       ["conda", "gstreamer"],
       ["debian", "libgstreamer1.0-dev"],
       ["homebrew", "gstreamer"],
-      ["macports", "gstreamer"],
+      ["macports", "gstreamer1"],
       ["msys2", "gstreamer"],
       ["rhel", "pkgconfig(gstreamer-1.0)"]
     ],
@@ -63,6 +63,7 @@ Gem::Specification.new do |s|
       ["arch_linux", "gst-plugins-base"],
       ["conda", "gst-plugins-base"],
       ["debian", "libgstreamer-plugins-base1.0-dev"],
+      ["macports", "gstreamer1-gst-plugins-base"],
       ["msys2", "gst-plugins-base"],
       ["rhel", "pkgconfig(gstreamer-audio-1.0)"]
     ]

--- a/gstreamer/test/test-sample.rb
+++ b/gstreamer/test/test-sample.rb
@@ -17,10 +17,14 @@
 require "fiddle"
 
 class TestSample < Test::Unit::TestCase
+  include GStreamerTestUtils
+
   AUDIO_TEST_SRC_DEFAULT_SAMPLES_PER_BUFFER = 1024
   AUDIO_TEST_SRC_RAMP = 1
 
   def test_memory_view_mono
+    only_gstreamer_version(1, 20)
+
     samples = generate_samples
 
     samples.each_with_index do |sample, i|
@@ -48,6 +52,8 @@ class TestSample < Test::Unit::TestCase
   end
 
   def test_memory_view_stereo
+    only_gstreamer_version(1, 20)
+
     samples = generate_samples(channels: 2)
 
     samples.each_with_index do |sample, i|
@@ -74,6 +80,8 @@ class TestSample < Test::Unit::TestCase
   end
 
   def test_memory_view_non_interleaved
+    only_gstreamer_version(1, 20)
+
     samples = generate_samples(layout: "non-interleaved", channels: 2)
 
     assert_raise(ArgumentError) do
@@ -82,6 +90,8 @@ class TestSample < Test::Unit::TestCase
   end
 
   def test_memory_view_unsupported_format
+    only_gstreamer_version(1, 20)
+
     samples = generate_samples(format: "S24_32LE")
 
     assert_raise(ArgumentError) do
@@ -90,6 +100,8 @@ class TestSample < Test::Unit::TestCase
   end
 
   def test_memory_view_from_buffer_list
+    only_gstreamer_version(1, 20)
+
     samples = generate_samples
     assert_equal(15, samples.size)
 

--- a/gstreamer/test/test-sample.rb
+++ b/gstreamer/test/test-sample.rb
@@ -26,7 +26,9 @@ class TestSample < Test::Unit::TestCase
     samples.each_with_index do |sample, i|
       Fiddle::MemoryView.export(sample) do |view|
         assert_equal(AUDIOTESTSRC_DEFAULT_SAMPLESPERBUFFER * 4, view.byte_size)
-        assert_true(view.readonly?)
+        assert do
+          view.readonly?
+        end
         assert_equal("e", view.format)
         assert_equal(4, view.item_size)
         assert_equal(2, view.ndim)
@@ -47,8 +49,10 @@ class TestSample < Test::Unit::TestCase
 
     samples.each_with_index do |sample, i|
       Fiddle::MemoryView.export(sample) do |view|
-        assert_equal(AUDIOTESTSRC_DEFAULT_SAMPLESPERBUFFER * 4 * 2, view.byte_size)
-        assert_true(view.readonly?)
+        assert_equal(AUDIO_TEST_SRC_DEFAULT_SAMPLES_PER_BUFFER * 4 * 2, view.byte_size)
+        assert do
+          view.readonly?
+        end
         assert_equal("e", view.format)
         assert_equal(4, view.item_size)
         assert_equal(2, view.ndim)
@@ -92,7 +96,7 @@ class TestSample < Test::Unit::TestCase
     samples.each do |sample|
       buffer = sample.buffer
       success, map = buffer.map(:read)
-      assert_equal true, success
+      assert_true(success)
       expected_data << map.data.pack("C*")
       buffer.unmap(map)
       buffer_list.insert(-1, buffer)

--- a/gstreamer/test/test-sample.rb
+++ b/gstreamer/test/test-sample.rb
@@ -17,28 +17,31 @@
 require "fiddle"
 
 class TestSample < Test::Unit::TestCase
-  AUDIOTESTSRC_DEFAULT_SAMPLESPERBUFFER = 1024
-  AUDIOTESTSRC_RAMP = 1
+  AUDIO_TEST_SRC_DEFAULT_SAMPLES_PER_BUFFER = 1024
+  AUDIO_TEST_SRC_RAMP = 1
 
   def test_memory_view_mono
     samples = generate_samples
 
     samples.each_with_index do |sample, i|
       Fiddle::MemoryView.export(sample) do |view|
-        assert_equal(AUDIOTESTSRC_DEFAULT_SAMPLESPERBUFFER * 4, view.byte_size)
+        assert_equal(AUDIO_TEST_SRC_DEFAULT_SAMPLES_PER_BUFFER * 4, view.byte_size)
         assert do
           view.readonly?
         end
         assert_equal("e", view.format)
         assert_equal(4, view.item_size)
         assert_equal(2, view.ndim)
-        assert_equal([AUDIOTESTSRC_DEFAULT_SAMPLESPERBUFFER, 1], view.shape)
+        assert_equal([AUDIO_TEST_SRC_DEFAULT_SAMPLES_PER_BUFFER, 1], view.shape)
         assert_equal([4, 4], view.strides)
         assert_nil(view.sub_offsets)
 
-        offset = AUDIOTESTSRC_DEFAULT_SAMPLESPERBUFFER * i
+        offset = AUDIO_TEST_SRC_DEFAULT_SAMPLES_PER_BUFFER * i
         (view.byte_size / view.item_size).times do |j|
-          assert_in_delta(Math.sin((offset + j + AUDIOTESTSRC_RAMP) * 2 * Math::PI * 440 / 16_000) * 0.8, view[j, 0], 0.001, "#{i}th buffer, #{j}th sample")
+          assert_in_delta(Math.sin((offset + j + AUDIO_TEST_SRC_RAMP) * 2 * Math::PI * 440 / 16_000) * 0.8,
+                          view[j, 0],
+                          0.001,
+                          "#{i}th buffer, #{j}th sample")
         end
       end
     end
@@ -56,14 +59,14 @@ class TestSample < Test::Unit::TestCase
         assert_equal("e", view.format)
         assert_equal(4, view.item_size)
         assert_equal(2, view.ndim)
-        assert_equal([AUDIOTESTSRC_DEFAULT_SAMPLESPERBUFFER, 2], view.shape)
+        assert_equal([AUDIO_TEST_SRC_DEFAULT_SAMPLES_PER_BUFFER, 2], view.shape)
         assert_equal([8, 4], view.strides)
         assert_nil(view.sub_offsets)
 
-        offset = AUDIOTESTSRC_DEFAULT_SAMPLESPERBUFFER * i
+        offset = AUDIO_TEST_SRC_DEFAULT_SAMPLES_PER_BUFFER * i
         (view.byte_size / view.item_size).times do |j|
           index, channel = j.divmod(2)
-          expected_value = Math.sin((offset + index + AUDIOTESTSRC_RAMP) * 2 * Math::PI * 440 / 16_000) * 0.8
+          expected_value = Math.sin((offset + index + AUDIO_TEST_SRC_RAMP) * 2 * Math::PI * 440 / 16_000) * 0.8
           assert_in_delta(expected_value, view[index, channel], 0.001, "#{i}th buffer, #{channel}th channel, #{index}th sample")
         end
       end
@@ -122,7 +125,7 @@ class TestSample < Test::Unit::TestCase
     convert = Gst::ElementFactory.make("audioconvert", nil)
     sink = Gst::ElementFactory.make("appsink", nil)
 
-    src.set_property("num-buffers", rate / AUDIOTESTSRC_DEFAULT_SAMPLESPERBUFFER)
+    src.set_property("num-buffers", rate / AUDIO_TEST_SRC_DEFAULT_SAMPLES_PER_BUFFER)
 
     caps = Gst::Caps.new("audio/x-raw")
     caps["format"] = format

--- a/gstreamer/test/test-sample.rb
+++ b/gstreamer/test/test-sample.rb
@@ -84,7 +84,7 @@ class TestSample < Test::Unit::TestCase
 
   def test_memory_view_from_buffer_list
     samples = generate_samples
-    assert_equal 15, samples.size
+    assert_equal(15, samples.size)
 
     buffer_list = Gst::BufferList.new
     expected_data = +"".b
@@ -103,8 +103,8 @@ class TestSample < Test::Unit::TestCase
     sample.buffer_list = buffer_list
 
     Fiddle::MemoryView.export(sample) do |view|
-      assert_equal expected_data.bytesize, view.byte_size
-      assert_equal expected_data, view.to_s
+      assert_equal(expected_data.bytesize, view.byte_size)
+      assert_equal(expected_data, view.to_s)
     end
   end
 

--- a/gstreamer/test/test-sample.rb
+++ b/gstreamer/test/test-sample.rb
@@ -1,0 +1,162 @@
+# Copyright (C) 2026  Ruby-GNOME Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+require "fiddle"
+
+class TestSample < Test::Unit::TestCase
+  AUDIOTESTSRC_DEFAULT_SAMPLESPERBUFFER = 1024
+  AUDIOTESTSRC_RAMP = 1
+
+  def test_memory_view_mono
+    samples = generate_samples
+
+    samples.each_with_index do |sample, i|
+      Fiddle::MemoryView.export(sample) do |view|
+        assert_equal(AUDIOTESTSRC_DEFAULT_SAMPLESPERBUFFER * 4, view.byte_size)
+        assert_true(view.readonly?)
+        assert_equal("e", view.format)
+        assert_equal(4, view.item_size)
+        assert_equal(2, view.ndim)
+        assert_equal([AUDIOTESTSRC_DEFAULT_SAMPLESPERBUFFER, 1], view.shape)
+        assert_equal([4, 4], view.strides)
+        assert_nil(view.sub_offsets)
+
+        offset = AUDIOTESTSRC_DEFAULT_SAMPLESPERBUFFER * i
+        (view.byte_size / view.item_size).times do |j|
+          assert_in_delta(Math.sin((offset + j + AUDIOTESTSRC_RAMP) * 2 * Math::PI * 440 / 16_000) * 0.8, view[j, 0], 0.001, "#{i}th buffer, #{j}th sample")
+        end
+      end
+    end
+  end
+
+  def test_memory_view_stereo
+    samples = generate_samples(channels: 2)
+
+    samples.each_with_index do |sample, i|
+      Fiddle::MemoryView.export(sample) do |view|
+        assert_equal(AUDIOTESTSRC_DEFAULT_SAMPLESPERBUFFER * 4 * 2, view.byte_size)
+        assert_true(view.readonly?)
+        assert_equal("e", view.format)
+        assert_equal(4, view.item_size)
+        assert_equal(2, view.ndim)
+        assert_equal([AUDIOTESTSRC_DEFAULT_SAMPLESPERBUFFER, 2], view.shape)
+        assert_equal([8, 4], view.strides)
+        assert_nil(view.sub_offsets)
+
+        offset = AUDIOTESTSRC_DEFAULT_SAMPLESPERBUFFER * i
+        (view.byte_size / view.item_size).times do |j|
+          index, channel = j.divmod(2)
+          expected_value = Math.sin((offset + index + AUDIOTESTSRC_RAMP) * 2 * Math::PI * 440 / 16_000) * 0.8
+          assert_in_delta(expected_value, view[index, channel], 0.001, "#{i}th buffer, #{channel}th channel, #{index}th sample")
+        end
+      end
+    end
+  end
+
+  def test_memory_view_non_interleaved
+    samples = generate_samples(layout: "non-interleaved", channels: 2)
+
+    assert_raise(ArgumentError) do
+      Fiddle::MemoryView.export(samples[0]) {}
+    end
+  end
+
+  def test_memory_view_unsupported_format
+    samples = generate_samples(format: "S24_32LE")
+
+    assert_raise(ArgumentError) do
+      Fiddle::MemoryView.export(samples[0]) {}
+    end
+  end
+
+  def test_memory_view_from_buffer_list
+    samples = generate_samples
+    assert_equal 15, samples.size
+
+    buffer_list = Gst::BufferList.new
+    expected_data = +"".b
+
+    samples.each do |sample|
+      buffer = sample.buffer
+      success, map = buffer.map(:read)
+      assert_equal true, success
+      expected_data << map.data.pack("C*")
+      buffer.unmap(map)
+      buffer_list.insert(-1, buffer)
+    end
+
+    caps = samples.first.caps
+    sample = Gst::Sample.new(Gst::Buffer.new, caps, Gst::Segment.new, caps.structures[0])
+    sample.buffer_list = buffer_list
+
+    Fiddle::MemoryView.export(sample) do |view|
+      assert_equal expected_data.bytesize, view.byte_size
+      assert_equal expected_data, view.to_s
+    end
+  end
+
+  private
+
+  def generate_samples(format: "F32LE", layout: "interleaved", rate: 16_000, channels: 1)
+    samples = []
+
+    pipeline = Gst::Pipeline.new("audio-generator")
+    src = Gst::ElementFactory.make("audiotestsrc", nil)
+    convert = Gst::ElementFactory.make("audioconvert", nil)
+    sink = Gst::ElementFactory.make("appsink", nil)
+
+    src.set_property("num-buffers", rate / AUDIOTESTSRC_DEFAULT_SAMPLESPERBUFFER)
+
+    caps = Gst::Caps.new("audio/x-raw")
+    caps["format"] = format
+    caps["rate", :int] = rate
+    caps["channels", :int] = channels
+    caps["layout"] = layout
+
+    sink.caps = caps
+    sink.emit_signals = true
+    sink.signal_connect :new_sample do |_|
+      samples << sink.pull_sample
+      Gst::FlowReturn::OK
+    end
+
+    pipeline << src << convert << sink
+    src >> convert >> sink
+
+    loop = GLib::MainLoop.new
+
+    bus = pipeline.bus
+    bus.add_watch do |bus, message|
+      case message.type
+      when Gst::MessageType::EOS
+        loop.quit
+      when Gst::MessageType::ERROR
+        error, debug = message.parse_error
+        raise "Error: #{error.message} (#{debug})"
+      end
+      true
+    end
+
+    pipeline.play
+    begin
+      loop.run
+    ensure
+      pipeline.stop
+    end
+
+    samples
+  end
+end

--- a/gstreamer/test/test-sample.rb
+++ b/gstreamer/test/test-sample.rb
@@ -127,32 +127,20 @@ class TestSample < Test::Unit::TestCase
     caps["layout"] = layout
 
     sink.caps = caps
-    sink.emit_signals = true
-    sink.signal_connect :new_sample do |_|
-      samples << sink.pull_sample
-      Gst::FlowReturn::OK
-    end
 
     pipeline << src << convert << sink
     src >> convert >> sink
 
-    loop = GLib::MainLoop.new
-
-    bus = pipeline.bus
-    bus.add_watch do |bus, message|
-      case message.type
-      when Gst::MessageType::EOS
-        loop.quit
-      when Gst::MessageType::ERROR
-        error, debug = message.parse_error
-        raise "Error: #{error.message} (#{debug})"
-      end
-      true
-    end
-
     pipeline.play
     begin
-      loop.run
+      loop do
+        sample = sink.try_pull_sample(Gst::SECOND)
+        if sample
+          samples << sample
+        else
+          break
+        end
+      end
     ensure
       pipeline.stop
     end

--- a/gstreamer/test/test-sample.rb
+++ b/gstreamer/test/test-sample.rb
@@ -121,7 +121,6 @@ class TestSample < Test::Unit::TestCase
     sample.buffer_list = buffer_list
 
     Fiddle::MemoryView.export(sample) do |view|
-      assert_equal(expected_data.bytesize, view.byte_size)
       assert_equal(expected_data, view.to_s)
     end
   end

--- a/gstreamer/test/test-sample.rb
+++ b/gstreamer/test/test-sample.rb
@@ -29,16 +29,26 @@ class TestSample < Test::Unit::TestCase
 
     samples.each_with_index do |sample, i|
       Fiddle::MemoryView.export(sample) do |view|
-        assert_equal(AUDIO_TEST_SRC_DEFAULT_SAMPLES_PER_BUFFER * 4, view.byte_size)
-        assert do
-          view.readonly?
-        end
-        assert_equal("e", view.format)
-        assert_equal(4, view.item_size)
-        assert_equal(2, view.ndim)
-        assert_equal([AUDIO_TEST_SRC_DEFAULT_SAMPLES_PER_BUFFER, 1], view.shape)
-        assert_equal([4, 4], view.strides)
-        assert_nil(view.sub_offsets)
+        assert_equal({
+                       byte_size: AUDIO_TEST_SRC_DEFAULT_SAMPLES_PER_BUFFER * 4,
+                       readonly?: true,
+                       format: "e",
+                       item_size: 4,
+                       ndim: 2,
+                       shape: [AUDIO_TEST_SRC_DEFAULT_SAMPLES_PER_BUFFER, 1],
+                       strides: [4, 4],
+                       sub_offsets: nil,
+                     },
+                     {
+                       byte_size: view.byte_size,
+                       readonly?: view.readonly?,
+                       format: view.format,
+                       item_size: view.item_size,
+                       ndim: view.ndim,
+                       shape: view.shape,
+                       strides: view.strides,
+                       sub_offsets: view.sub_offsets,
+                     })
 
         offset = AUDIO_TEST_SRC_DEFAULT_SAMPLES_PER_BUFFER * i
         (view.byte_size / view.item_size).times do |j|

--- a/gstreamer/test/test-sample.rb
+++ b/gstreamer/test/test-sample.rb
@@ -58,16 +58,26 @@ class TestSample < Test::Unit::TestCase
 
     samples.each_with_index do |sample, i|
       Fiddle::MemoryView.export(sample) do |view|
-        assert_equal(AUDIO_TEST_SRC_DEFAULT_SAMPLES_PER_BUFFER * 4 * 2, view.byte_size)
-        assert do
-          view.readonly?
-        end
-        assert_equal("e", view.format)
-        assert_equal(4, view.item_size)
-        assert_equal(2, view.ndim)
-        assert_equal([AUDIO_TEST_SRC_DEFAULT_SAMPLES_PER_BUFFER, 2], view.shape)
-        assert_equal([8, 4], view.strides)
-        assert_nil(view.sub_offsets)
+        assert_equal({
+                        byte_size: AUDIO_TEST_SRC_DEFAULT_SAMPLES_PER_BUFFER * 4 * 2
+                        readonly?: true,
+                        format: "e",
+                        item_size: 4,
+                        ndim: 2,
+                        shape: [AUDIO_TEST_SRC_DEFAULT_SAMPLES_PER_BUFFER, 2],
+                        strides: [8, 4],
+                        sub_offsets: nil,
+                     },
+                     {
+                       byte_size: view.byte_size,
+                       readonly?: view.readonly?
+                       format: view.format,
+                       item_size: view.item_size,
+                       ndim: view.ndim,
+                       shape: view.shape,
+                       strides: view.strides,
+                       sub_offsets: view.sub_offsets,
+                     })
 
         offset = AUDIO_TEST_SRC_DEFAULT_SAMPLES_PER_BUFFER * i
         (view.byte_size / view.item_size).times do |j|

--- a/gstreamer/test/test-sample.rb
+++ b/gstreamer/test/test-sample.rb
@@ -59,7 +59,7 @@ class TestSample < Test::Unit::TestCase
     samples.each_with_index do |sample, i|
       Fiddle::MemoryView.export(sample) do |view|
         assert_equal({
-                        byte_size: AUDIO_TEST_SRC_DEFAULT_SAMPLES_PER_BUFFER * 4 * 2
+                        byte_size: AUDIO_TEST_SRC_DEFAULT_SAMPLES_PER_BUFFER * 4 * 2,
                         readonly?: true,
                         format: "e",
                         item_size: 4,
@@ -70,7 +70,7 @@ class TestSample < Test::Unit::TestCase
                      },
                      {
                        byte_size: view.byte_size,
-                       readonly?: view.readonly?
+                       readonly?: view.readonly?,
                        format: view.format,
                        item_size: view.item_size,
                        ndim: view.ndim,

--- a/gstreamer/test/test-sample.rb
+++ b/gstreamer/test/test-sample.rb
@@ -110,10 +110,9 @@ class TestSample < Test::Unit::TestCase
 
     samples.each do |sample|
       buffer = sample.buffer
-      success, map = buffer.map(:read)
-      assert_true(success)
-      expected_data << map.data.pack("C*")
-      buffer.unmap(map)
+      buffer.map(:read) do |map|
+        expected_data << map.data.pack("C*")
+      end
       buffer_list.insert(-1, buffer)
     end
 


### PR DESCRIPTION
Hi,

I made `Gst::Sample` export MemoryView for #1634.
(Sorry for big commits.)

But, it's not perfect. Could you advise me?

* Only audio is supported, because my primary motivation is speech-to-text from microphone. Is video support needed?
* Only row-major data is supported
* Only interleaved audio is supported
* Some formats like `GST_AUDIO_FORMAT_S24_32LE` are not supported because I couldn't find way to handle them. Is there a way to export such format to MemoryView?
* I'm not really sure of endianness because I'm not familiar with low level programming
* I'm not sure of the way of setup sample audio data in test is good or not. Current way to setup audio (`generate_samples`) is not performant

Any advice is appreciated.

Example for speech-to-text from microphone below works with this pull request and whispercpp's [pre-pull-request branch](https://github.com/KitaitiMakoto/whisper.cpp/):

```ruby:sample/asr.rb
require "gst"
require "whisper"

pipeline = Gst::Pipeline.new("asr")
src = Gst::ElementFactory.make("autoaudiosrc", nil)
raise "need audiotestsrc from gst-plugins-good" if src.nil?
resample = Gst::ElementFactory.make("audioresample", nil)
raise "need audioresample from gst-plugins-base" if resample.nil?
sink = Gst::ElementFactory.make("appsink", nil)
raise "need appsink from gst-plugins-base" if sink.nil?

caps = Gst::Caps.new("audio/x-raw")
caps["format"] = "F32LE"
caps["rate", :int] = 16_000
caps["channels", :int] = 1
caps["layout"] = "interleaved"

sink.caps = caps
sink.emit_signals = true

duration_threshold = 3_000_000_000 # nanoseconds
whisper = Whisper::Context.new("tiny-q8_0")
params = Whisper::Params.new(language: "ja")

buffer_list = Gst::BufferList.new

duration = 0
sink.signal_connect(:new_sample) do |_|
  sample = sink.pull_sample
  buffer = sample.buffer
  dur = buffer.duration
  next Gst::FlowReturn::OK if dur == Gst::CLOCK_TIME_NONE

  buffer_list.insert -1, sample.buffer
  duration += dur
  next Gst::FlowReturn::OK unless duration >= duration_threshold

  samples = Gst::Sample.new(Gst::Buffer.new, caps, Gst::Segment.new, caps.structures[0])
  samples.buffer_list = buffer_list
  buffer_list = Gst::BufferList.new
  duration = 0
  begin
    # Should run in thread?
    puts whisper.full(params, samples).to_webvtt
  rescue => err
    warn err
  end
  Gst::FlowReturn::OK
end

pipeline << src << resample << sink
src >> resample >> sink

loop = GLib::MainLoop.new

bus = pipeline.bus
bus.add_watch do |bus, message|
  case message.type
  when Gst::MessageType::EOS
    puts "End-of-stream"
    loop.quit
  when Gst::MessageType::ERROR
    error, debug = message.parse_error
    puts "Debugging info: #{debug || 'none'}"
    puts "Error: #{error.message}"
    loop.quit
  end
  true
end

pipeline.play
begin
  loop.run
rescue Interrupt
  puts "Interrupt"
rescue => error
  puts "Error: #{error.message}"
ensure
  pipeline.stop
end
```

```
% ruby -Iext/gstreamer -I../../../ggml-org/whisper.cpp/bindings/ruby/lib ./sample/asr.rb
whisper_init_from_file_with_params_no_state: loading model from '/Users/kitaitimakoto/Library/Caches/whisper.cpp/huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny-q8_0.bin'
whisper_init_with_params_no_state: use gpu    = 1

(snip)

whisper_init_state: compute buffer (decode) =   96.83 MB
WEBVTT

1
00:00:00.000 --> 00:00:03.000
あ、あ、こんにちは。

^CInterrupt
ggml_metal_free: deallocating
```

Thank you.