### PR TITLE
gstreamer: Make Gst::Buffer#map raise an exception on failure

### DIFF
--- a/gstreamer/lib/gst/buffer.rb
+++ b/gstreamer/lib/gst/buffer.rb
@@ -1,0 +1,39 @@
+# Copyright (C) 2026  Ruby-GNOME Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gst
+  class Buffer
+    alias_method :map_raw, :map
+    def map(flags)
+      success, info = map_raw(flags)
+      unless success
+        unmap
+        raise "failed to map buffer"
+      end
+      info
+    end
+
+    alias_method :map_range_raw, :map_range
+    def map_range(idx, length, flags)
+      success, info = map_range_raw(idx, length, flags)
+      unless success
+        unmap
+        raise "failed to map buffer"
+      end
+      info
+    end
+  end
+end

--- a/gstreamer/lib/gst/buffer.rb
+++ b/gstreamer/lib/gst/buffer.rb
@@ -19,7 +19,7 @@ module Gst
     alias_method :map_raw, :map
     def map(flags)
       success, info = map_raw(flags)
-      raise "failed to map buffer" unless success
+      raise Gst::CoreError::Failed.new("failed to map buffer") unless success
       info
     end
 

--- a/gstreamer/lib/gst/buffer.rb
+++ b/gstreamer/lib/gst/buffer.rb
@@ -26,7 +26,7 @@ module Gst
     alias_method :map_range_raw, :map_range
     def map_range(idx, length, flags)
       success, info = map_range_raw(idx, length, flags)
-      raise "failed to map buffer range" unless success
+      raise Gst::CoreError::Failed.new("failed to map buffer") unless success
       info
     end
   end

--- a/gstreamer/lib/gst/buffer.rb
+++ b/gstreamer/lib/gst/buffer.rb
@@ -19,20 +19,14 @@ module Gst
     alias_method :map_raw, :map
     def map(flags)
       success, info = map_raw(flags)
-      unless success
-        unmap
-        raise "failed to map buffer"
-      end
+      raise "failed to map buffer" unless success
       info
     end
 
     alias_method :map_range_raw, :map_range
     def map_range(idx, length, flags)
       success, info = map_range_raw(idx, length, flags)
-      unless success
-        unmap
-        raise "failed to map buffer"
-      end
+      raise "failed to map buffer range" unless success
       info
     end
   end

--- a/gstreamer/lib/gst/loader.rb
+++ b/gstreamer/lib/gst/loader.rb
@@ -61,6 +61,7 @@ module Gst
     def require_libraries
       require "gst/bin"
       require "gst/bus"
+      require "gst/buffer"
       require "gst/caps"
       require "gst/element"
       require "gst/element-factory"

--- a/gstreamer/lib/gst/loader.rb
+++ b/gstreamer/lib/gst/loader.rb
@@ -60,8 +60,8 @@ module Gst
 
     def require_libraries
       require "gst/bin"
-      require "gst/bus"
       require "gst/buffer"
+      require "gst/bus"
       require "gst/caps"
       require "gst/element"
       require "gst/element-factory"

--- a/gstreamer/sample/audio-extract.rb
+++ b/gstreamer/sample/audio-extract.rb
@@ -37,7 +37,7 @@ sink.emit_signals = true
 sink.signal_connect(:new_sample) do |_|
   sample = sink.pull_sample
   buffer = sample.buffer
-  success, map = buffer.map(:read)
+  map = buffer.map(:read)
   p map.data
   buffer.unmap(map)
   Gst::FlowReturn::OK

--- a/gstreamer/test/test-buffer.rb
+++ b/gstreamer/test/test-buffer.rb
@@ -44,7 +44,7 @@ class TestBuffer < Test::Unit::TestCase
       sample = @sink.try_pull_sample(Gst::SECOND)
       buffer = sample.buffer
 
-      assert_raise(RuntimeError) do
+      assert_raise(Gst::CoreError::Failed) do
         buffer.map(:write)
       end
     ensure
@@ -73,7 +73,7 @@ class TestBuffer < Test::Unit::TestCase
       sample = @sink.try_pull_sample(Gst::SECOND)
       buffer = sample.buffer
 
-      assert_raise(RuntimeError) do
+      assert_raise(Gst::CoreError::Failed) do
         buffer.map_range(0, -1, :write)
       end
     ensure

--- a/gstreamer/test/test-buffer.rb
+++ b/gstreamer/test/test-buffer.rb
@@ -1,0 +1,97 @@
+# Copyright (C) 2026  Ruby-GNOME Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+class TestBuffer < Test::Unit::TestCase
+  def setup
+    unless Gst::ElementFactory.find("videotestsrc")
+      omit("gst-plugins-good is needed")
+    end
+    @pipeline = Gst.parse_launch("videotestsrc ! appsink name=sink")
+    @sink = @pipeline.get_by_name("sink")
+  end
+
+  def test_map
+    @pipeline.play
+    begin
+      sample = @sink.try_pull_sample(Gst::SECOND)
+      buffer = sample.buffer
+      map_info = buffer.map(:read)
+
+      assert do
+        map_info.data.size >= 115200
+      end
+    ensure
+      @pipeline.stop
+    end
+  end
+
+  def test_map_fail
+    @pipeline.play
+    begin
+      sample = @sink.try_pull_sample(Gst::SECOND)
+      buffer = sample.buffer
+
+      assert_raise(RuntimeError) do
+        buffer.map(:write)
+      end
+    ensure
+      @pipeline.stop
+    end
+  end
+
+  def test_map_range_full
+    @pipeline.play
+    begin
+      sample = @sink.try_pull_sample(Gst::SECOND)
+      buffer = sample.buffer
+      map_info = buffer.map_range(0, -1, :read)
+
+      assert do
+        map_info.data.size >= 115200
+      end
+    ensure
+      @pipeline.stop
+    end
+  end
+
+  def test_map_range_full_fail
+    @pipeline.play
+    begin
+      sample = @sink.try_pull_sample(Gst::SECOND)
+      buffer = sample.buffer
+
+      assert_raise(RuntimeError) do
+        buffer.map_range(0, -1, :write)
+      end
+    ensure
+      @pipeline.stop
+    end
+  end
+
+  def test_map_range_partial
+    allocator = Gst::Allocator.find
+    memory1 = allocator.alloc(100)
+    memory2 = allocator.alloc(200)
+    memory3 = allocator.alloc(300)
+    buffer = Gst::Buffer.new
+    buffer.append_memory(memory1)
+    buffer.append_memory(memory2)
+    buffer.append_memory(memory3)
+    map_info = buffer.map_range(1, 2, :read)
+
+    assert_equal(500, map_info.data.size)
+  end
+end

--- a/gstreamer/test/test-map-info.rb
+++ b/gstreamer/test/test-map-info.rb
@@ -28,8 +28,7 @@ class TestMapInfo < Test::Unit::TestCase
     begin
       sample = @sink.try_pull_sample(Gst::SECOND)
       buffer = sample.buffer
-      success, map_info = buffer.map(:read)
-      assert_true(success)
+      map_info = buffer.map(:read)
       assert do
         map_info.data.size >= 115200
       end


### PR DESCRIPTION
Hi,

This pull request makes `Gst::Buffer#map` raise an exception on failure as said at https://github.com/ruby-gnome/ruby-gnome/pull/1704#discussion_r3030949967

You know, this is a breaking change. Should we put a deprecation period that `Gst::Buffer#map` returns `[success, map]` or `[map, map]`?

Thank you.