### PR TITLE
Remove version spec from commonmarker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ group :development, :docs, :test do
 end
 
 group :docs do
-  gem "commonmarker", "~> 0.21"
+  gem "commonmarker"
   gem "rdoc"
   gem "yard"
   gem "yard-gobject-introspection",


### PR DESCRIPTION
Hi,

Now we can use the latest commonmarker with the latest YARD: https://github.com/lsegal/yard/issues/1528#issuecomment-4234687311
