### PR TITLE
glib2: don't free a TypedData object's own rb_data_type_t in cinfo_free

### DIFF
--- a/glib2/ext/glib2/rbgobj_type.c
+++ b/glib2/ext/glib2/rbgobj_type.c
@@ -68,7 +68,13 @@ cinfo_free(void *data)
     RGObjClassInfo *cinfo = data;
     g_hash_table_remove(gtype_to_cinfo, GUINT_TO_POINTER(cinfo->gtype));
     xfree(cinfo->name);
-    xfree(cinfo->data_type);
+    /* Don't free cinfo->data_type here: it is this object's own
+     * rb_data_type_t, and the GC still reads its ->flags after this
+     * free callback returns (RUBY_TYPED_EMBEDDABLE check in
+     * rb_data_free, Ruby >= 3.3). Freeing it would be a use-after-free.
+     * A subclass' rb_data_type_t may also reference it via ->parent.
+     * These per-class type descriptors live for the lifetime of the
+     * registered class, so leaving them allocated is intentional. */
     xfree(cinfo);
 }
 

--- a/glib2/test/test-type-gc.rb
+++ b/glib2/test/test-type-gc.rb
@@ -1,0 +1,72 @@
+# Copyright (C) 2026  Ruby-GNOME Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+require "rbconfig"
+
+class TestGLibTypeGC < Test::Unit::TestCase
+  include GLibTestUtils
+
+  # Regression test for a heap-use-after-free during interpreter
+  # shutdown.
+  #
+  # Every class registered through the rbgobj type system (G_DEF_CLASS,
+  # GObjectIntrospection's define_class, ...) is wrapped by an
+  # RGObjClassInfo TypedData object whose rb_data_type_t is heap
+  # allocated per class (rbgobj_class_info_create_data_type). cinfo_free
+  # used to free that rb_data_type_t (xfree(cinfo->data_type)), but the
+  # GC reads RTYPEDDATA_TYPE(obj)->flags *after* invoking the free
+  # callback (RUBY_TYPED_EMBEDDABLE check in rb_data_free, Ruby >= 3.3),
+  # so freeing the type struct from within its own dfree is a
+  # use-after-free.
+  #
+  # These cinfo objects are pinned for the whole process (klass_to_cinfo),
+  # so they are only freed by the shutdown finalizer
+  # (rb_objspace_call_finalizer). We therefore exercise the bug in a
+  # child process that simply loads glib2 and exits.
+  #
+  # The fault is only *detected* by a memory checker (an
+  # AddressSanitizer/valgrind enabled Ruby). On a normal build the freed
+  # struct is still mapped, so this test passes trivially and just acts
+  # as a smoke test.
+  def test_shutdown_does_not_use_freed_data_type
+    code = <<~RUBY
+      require "glib2"
+      # Touch a handful of classes that are registered through the
+      # rbgobj cinfo path; each owns a heap-allocated rb_data_type_t
+      # that is freed by the shutdown finalizer.
+      [
+        GLib::Bytes,
+        GLib::VariantType,
+        GLib::DateTime,
+        GLib::Regex,
+      ]
+      GC.start
+    RUBY
+
+    load_path_options = $LOAD_PATH.flat_map {|path| ["-I", path]}
+    command = [RbConfig.ruby, *load_path_options, "-e", code]
+    output = IO.popen(command, err: [:child, :out], &:read)
+    status = $?
+
+    assert(status.success?,
+           "child process did not exit cleanly " \
+           "(possible use-after-free at shutdown)\n" \
+           "status: #{status.inspect}\n" \
+           "output:\n#{output}")
+  rescue NotImplementedError
+    omit("Spawning a child process isn't supported on this platform")
+  end
+end


### PR DESCRIPTION
Each class registered through the rbgobj type system (G_DEF_CLASS,
GObjectIntrospection's define_class, ...) is wrapped by an
RGObjClassInfo TypedData object whose rb_data_type_t is heap allocated
per class in rbgobj_class_info_create_data_type. cinfo_free freed that
struct via xfree(cinfo->data_type).

That is a use-after-free. After invoking the dfree callback,
rb_data_free reads RTYPEDDATA_TYPE(obj)->flags to evaluate the
RUBY_TYPED_EMBEDDABLE check (Ruby >= 3.3, commit 392238e3fd "Implement
embedded TypedData objects"), so the type struct must outlive the free
callback. A subclass' rb_data_type_t may also reference it via ->parent.
AddressSanitizer reports a heap-use-after-free in rb_data_free during
rb_objspace_call_finalizer at interpreter shutdown, when these pinned
cinfo objects are finally collected.

Stop freeing cinfo->data_type. These per-class type descriptors live for
the lifetime of the registered class, so leaving them allocated is
intentional and matches the usual rb_data_type_t lifetime contract.

Add a regression test that loads glib2 in a child process and asserts it
exits cleanly; this fails (SIGABRT) under an ASAN/valgrind build before
the fix and passes after.

This essentially leaks the type.  A better alternative would be to declare the type statically as is usually done: https://github.com/ruby-gnome/ruby-gnome/pull/1714