### PR TITLE
Remove vm_throw_data.reserved field when ruby >= 4.1

### DIFF
--- a/glib2/ext/glib2/rbglib_regex.c
+++ b/glib2/ext/glib2/rbglib_regex.c
@@ -19,16 +19,30 @@
 
 #include "rbgprivate.h"
 
+#include <ruby/version.h> /* for RUBY_API_VERSION_CODE (vm_throw_data layout) */
+
 /* They MRI are internal definitions. Using them reduces
  * maintainability. We should reconsider about using them when they
  * are changed in MRI. */
 /* from vm_core.h */
 #define RUBY_TAG_BREAK 0x2
 
-/* from internal.h */
+/* from internal/imemo.h
+ *
+ * WARNING: This mirrors a private MRI struct so we can read the value
+ * carried by a `break` out of a throw_data (rb_errinfo() after rb_protect
+ * catches RUBY_TAG_BREAK). Its layout MUST be kept in sync with MRI.
+ *
+ * The `reserved` field (an unused IMEMO header slot) was removed in Ruby
+ * 4.1 by commit ff55280320 ("Remove useless reserved field in
+ * vm_throw_data"). With the field present on 4.1+, `throw_obj` is read at
+ * the wrong offset and resolves to `catch_frame` (a VM stack pointer),
+ * which the GC then treats as a garbage object. */
 struct vm_throw_data {
     VALUE flags;
+#if RUBY_API_VERSION_CODE < 40100
     VALUE reserved;
+#endif
     const VALUE throw_obj;
     /* const struct rb_control_frame_struct *catch_frame; */
     /* VALUE throw_state; */

--- a/glib2/test/test-regex.rb
+++ b/glib2/test/test-regex.rb
@@ -287,6 +287,29 @@ class TestRegex < Test::Unit::TestCase
         end
         assert_equal(" to 3 2 1", modified_string)
       end
+
+      # Regression test: the value carried by `break` must be read back
+      # correctly from the throw data inside the C replace callback. A stale
+      # copy of MRI's internal vm_throw_data layout used to read it at the
+      # wrong offset, yielding a garbage VALUE instead of this string. Using a
+      # long, freshly-allocated (non-literal) replacement makes an accidental
+      # match against garbage effectively impossible.
+      test "break returns a dynamically built value" do
+        regex = GLib::Regex.new("\\d")
+        replacement = "X" * 50
+        modified_string = regex.replace("a1b2c3") do |match_info|
+          break replacement
+        end
+        assert_equal("a#{replacement}b2c3", modified_string)
+      end
+
+      test "break value can be derived from the match" do
+        regex = GLib::Regex.new("[0-9]+")
+        modified_string = regex.replace("foo 12 bar 34") do |match_info|
+          break "<#{match_info.fetch(0)}>"
+        end
+        assert_equal("foo <12> bar 34", modified_string)
+      end
     end
   end
 


### PR DESCRIPTION
The field was removed in https://github.com/ruby/ruby/commit/ff55280320
