### PR TITLE
glib2: use a shared static rb_data_type_t for RGObjClassInfo

### DIFF
--- a/glib2/ext/glib2/rbgobj_type.c
+++ b/glib2/ext/glib2/rbgobj_type.c
@@ -68,9 +68,24 @@ cinfo_free(void *data)
     RGObjClassInfo *cinfo = data;
     g_hash_table_remove(gtype_to_cinfo, GUINT_TO_POINTER(cinfo->gtype));
     xfree(cinfo->name);
-    xfree(cinfo->data_type);
     xfree(cinfo);
 }
+
+/* All RGObjClassInfo wrappers share this single immutable type. It must
+ * outlive every wrapper object, because the GC reads its ->flags after
+ * the dfree callback returns (the RUBY_TYPED_EMBEDDABLE check in
+ * rb_data_free, Ruby >= 3.3). It is therefore static rather than
+ * allocated and freed per class. */
+static const rb_data_type_t rg_class_info_type = {
+    "RGObjClassInfo",
+    {
+        cinfo_mark,
+        cinfo_free,
+    },
+    NULL,
+    NULL,
+    RUBY_TYPED_FREE_IMMEDIATELY,
+};
 
 static RGObjClassInfo *
 rbgobj_class_info_define_without_lock(GType gtype,
@@ -99,52 +114,24 @@ rbgobj_class_info_fill_name(RGObjClassInfo *cinfo)
     cinfo->name = RB_ALLOC_N(char, RSTRING_LEN(rb_name) + 1);
     memcpy(cinfo->name, RSTRING_PTR(rb_name), RSTRING_LEN(rb_name));
     cinfo->name[RSTRING_LEN(rb_name)] = '\0';
-    cinfo->data_type->wrap_struct_name = cinfo->name;
-}
-
-static rb_data_type_t *
-rbgobj_class_info_create_data_type(VALUE klass)
-{
-    rb_data_type_t *data_type;
-
-    data_type = RB_ZALLOC(rb_data_type_t);
-    data_type->wrap_struct_name = "RGObjClassInfo";
-    data_type->function.dmark = cinfo_mark;
-    data_type->function.dfree = cinfo_free;
-    if (RB_TYPE_P(klass, RUBY_T_CLASS) && klass != rb_cObject) {
-        VALUE p = RCLASS_SUPER(klass);
-        while (p != rb_cObject) {
-            if (RB_TYPE_P(p, RUBY_T_DATA) && RTYPEDDATA_P(p)) {
-                data_type->parent = RTYPEDDATA_TYPE(p);
-                break;
-            }
-            p = RCLASS_SUPER(p);
-        }
-    }
-    data_type->flags = RUBY_TYPED_FREE_IMMEDIATELY;
-
-    return data_type;
 }
 
 static RGObjClassInfo *
 rbgobj_class_info_register_without_lock(GType gtype, VALUE klass)
 {
-    rb_data_type_t *data_type;
     RGObjClassInfo *cinfo;
     GType fundamental_type;
     RGObjClassInfoDynamic *cinfod;
     void *gclass = NULL;
     VALUE c;
 
-    data_type = rbgobj_class_info_create_data_type(klass);
-    c = TypedData_Make_Struct(rb_cObject, RGObjClassInfo, data_type, cinfo);
+    c = TypedData_Make_Struct(rb_cObject, RGObjClassInfo, &rg_class_info_type, cinfo);
     cinfo->klass = klass;
     cinfo->gtype = gtype;
     cinfo->mark  = NULL;
     cinfo->free  = NULL;
     cinfo->flags = 0;
     cinfo->name = NULL;
-    cinfo->data_type = data_type;
     rbgobj_class_info_fill_name(cinfo);
 
     fundamental_type = G_TYPE_FUNDAMENTAL(gtype);
@@ -367,7 +354,7 @@ rbgobj_class_info_lookup(VALUE klass)
         RGObjClassInfo *cinfo;
         TypedData_Get_Struct(data,
                              RGObjClassInfo,
-                             RTYPEDDATA_TYPE(data),
+                             &rg_class_info_type,
                              cinfo);
         return cinfo;
     }
@@ -523,13 +510,11 @@ rbgobj_register_class(VALUE klass,
                       gboolean klass2gtype,
                       gboolean gtype2klass)
 {
-    rb_data_type_t *data_type = NULL;
     RGObjClassInfo *cinfo = NULL;
     VALUE c = Qnil;
 
     if (klass2gtype) {
-        data_type = rbgobj_class_info_create_data_type(klass);
-        c = TypedData_Make_Struct(rb_cObject, RGObjClassInfo, data_type, cinfo);
+        c = TypedData_Make_Struct(rb_cObject, RGObjClassInfo, &rg_class_info_type, cinfo);
     }
     if (gtype2klass && !cinfo)
         cinfo = g_new(RGObjClassInfo, 1);
@@ -540,7 +525,6 @@ rbgobj_register_class(VALUE klass,
         cinfo->mark  = NULL;
         cinfo->free  = NULL;
         cinfo->flags = 0;
-        cinfo->data_type = data_type;
     }
 
     if (klass2gtype)
@@ -662,7 +646,7 @@ rg_s_try_convert(VALUE self, VALUE value)
 
             TypedData_Get_Struct(data,
                                  RGObjClassInfo,
-                                 RTYPEDDATA_TYPE(data),
+                                 &rg_class_info_type,
                                  cinfo);
             return rb_funcall(self, id_new, 1, SIZET2NUM(cinfo->gtype));
         }

--- a/glib2/ext/glib2/rbgobject.h
+++ b/glib2/ext/glib2/rbgobject.h
@@ -132,7 +132,6 @@ typedef struct {
     RGFreeFunc free;
     int flags; /* RGObjClassFlag */
     gchar *name;
-    rb_data_type_t *data_type;
 } RGObjClassInfo;
 
 /* rbgobject.c */

--- a/glib2/test/test-type-gc.rb
+++ b/glib2/test/test-type-gc.rb
@@ -1,0 +1,73 @@
+# Copyright (C) 2026  Ruby-GNOME Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+require "rbconfig"
+
+class TestGLibTypeGC < Test::Unit::TestCase
+  include GLibTestUtils
+
+  # Regression test for a heap-use-after-free during interpreter
+  # shutdown.
+  #
+  # Every class registered through the rbgobj type system (G_DEF_CLASS,
+  # GObjectIntrospection's define_class, ...) is wrapped by an
+  # RGObjClassInfo TypedData object. cinfo_free used to free the
+  # object's own rb_data_type_t (xfree(cinfo->data_type)), but the GC
+  # reads RTYPEDDATA_TYPE(obj)->flags *after* invoking the free callback
+  # (RUBY_TYPED_EMBEDDABLE check in rb_data_free, Ruby >= 3.3), so
+  # freeing the type struct from within its own dfree is a
+  # use-after-free. All RGObjClassInfo wrappers now share a single
+  # static rb_data_type_t (rg_class_info_type) that outlives every
+  # wrapper, making this structurally impossible.
+  #
+  # These cinfo objects are pinned for the whole process (klass_to_cinfo),
+  # so they are only freed by the shutdown finalizer
+  # (rb_objspace_call_finalizer). We therefore exercise the bug in a
+  # child process that simply loads glib2 and exits.
+  #
+  # The fault is only *detected* by a memory checker (an
+  # AddressSanitizer/valgrind enabled Ruby). On a normal build the freed
+  # struct is still mapped, so this test passes trivially and just acts
+  # as a smoke test.
+  def test_shutdown_does_not_use_freed_data_type
+    code = <<~RUBY
+      require "glib2"
+      # Touch a handful of classes that are registered through the
+      # rbgobj cinfo path; each is wrapped by an RGObjClassInfo whose
+      # dfree (cinfo_free) runs in the shutdown finalizer.
+      [
+        GLib::Bytes,
+        GLib::VariantType,
+        GLib::DateTime,
+        GLib::Regex,
+      ]
+      GC.start
+    RUBY
+
+    load_path_options = $LOAD_PATH.flat_map {|path| ["-I", path]}
+    command = [RbConfig.ruby, *load_path_options, "-e", code]
+    output = IO.popen(command, err: [:child, :out], &:read)
+    status = $?
+
+    assert(status.success?,
+           "child process did not exit cleanly " \
+           "(possible use-after-free at shutdown)\n" \
+           "status: #{status.inspect}\n" \
+           "output:\n#{output}")
+  rescue NotImplementedError
+    omit("Spawning a child process isn't supported on this platform")
+  end
+end


### PR DESCRIPTION
Every class registered through the rbgobj type system was wrapped by an
RGObjClassInfo TypedData object with its own per-class, heap-allocated
rb_data_type_t. cinfo_free freed that type via xfree(cinfo->data_type),
but the GC reads RTYPEDDATA_TYPE(obj)->flags after the dfree callback
returns (the RUBY_TYPED_EMBEDDABLE check in rb_data_free, Ruby >= 3.3),
which is a heap-use-after-free at interpreter shutdown.

Replace the per-class descriptor with a single immutable static
rb_data_type_t (rg_class_info_type) shared by all wrappers. It outlives
every wrapper, so the post-dfree flags read is always valid and the UAF
is structurally impossible. This also removes the per-class allocation
and the dead parent-walk in rbgobj_class_info_create_data_type.

The TypedData API expects this descriptor to be a single immutable,
process-lifetime value shared by all instances of a kind, not a
per-class heap allocation; see Ruby's extension guide ("data_type is a
pointer to a const rb_data_type_t", wrap_struct_name "must be unique in
the process", and the static const examples):
https://docs.ruby-lang.org/en/master/extension_rdoc.html

Because the type is now shared, wrap_struct_name is the constant
"RGObjClassInfo" for every wrapper instead of the per-class Ruby class
name; this only affects diagnostic output (ObjectSpace dumps, TypedData
type-mismatch messages) for these internal bookkeeping objects.

Add a regression test that loads glib2 in a child process and asserts a
clean exit (detectable under an ASAN/valgrind Ruby).
