### PR TITLE
fix(glib2): keep object-valued properties set via the set_property vfunc from being GC'd

### DIFF
--- a/glib2/ext/glib2/rbgobj_object.c
+++ b/glib2/ext/glib2/rbgobj_object.c
@@ -974,7 +974,14 @@ set_prop_func(GObject* object,
         g_free(name);
     }
 
-    rb_funcall(GOBJ2RVAL(object), ruby_setter, 1, GVAL2RVAL(value));
+    {
+        VALUE rb_object = GOBJ2RVAL(object);
+        VALUE rb_value = GVAL2RVAL(value);
+        rb_funcall(rb_object, ruby_setter, 1, rb_value);
+        if (G_TYPE_IS_OBJECT(G_PARAM_SPEC_VALUE_TYPE(pspec))) {
+            G_CHILD_SET(rb_object, rb_intern(g_param_spec_get_name(pspec)), rb_value);
+        }
+    }
 }
 
 void


### PR DESCRIPTION
Refactor setter function to handle object types and set child values. See issue #1718 for reference. Below copied from it.

The reproducer below needs only `glib2` -- no GTK.

## Summary

An object-valued property of a Ruby-defined `GLib::Object` subclass can be garbage-collected while the owning object still holds it, when the value is delivered through the GObject `set_property` *vfunc* rather than through Ruby's `Object#set_property`. The vfunc is the path taken by **property bindings** and **`g_object_set` from C**. The value's Ruby wrapper ends up rooted nowhere; the next GC reclaims it, and a later access segfaults or raises `GLib::NoPropertyError` (the symptoms in #1688).

The defect predates Ruby 4.0 but is latent on older runtimes; 4.0's more eager reclamation and reuse of freed slots makes it deterministic. (The garbage type varying between runs -- String, Array, ... -- is the signature of a reused object slot, not a bad value.)

## Steps to reproduce

Deterministic, pure-glib2, prints PASS/FAIL:
```ruby
    require "glib2"
    require "weakref"

    class Leaf < GLib::Object
      type_register
    end

    # Binding source: stores the value so the binding can read it.
    class Source < GLib::Object
      type_register
      install_property(GLib::Param::Object.new("obj", "obj", "obj", Leaf,
        GLib::Param::READABLE | GLib::Param::WRITABLE))
      def obj=(value); @obj = value; end
      def obj; @obj; end
    end

    # Binding target: WRITABLE-only (so GC mark never calls a getter on it),
    # with a non-retaining setter -- the value arrives via the vfunc and the
    # owner keeps no Ruby reference to it.
    class Owner < GLib::Object
      type_register
      install_property(GLib::Param::Object.new("obj", "obj", "obj", Leaf,
        GLib::Param::WRITABLE))
      def obj=(_value); end
    end

    source = Source.new
    owner  = Owner.new
    leaf   = Leaf.new
    leaf_ref = WeakRef.new(leaf)
    source.obj = leaf

    # SYNC_CREATE copies source.obj -> owner.obj once, through owner's
    # set_property vfunc -- NOT through Object#set_property (which already roots
    # the value).
    binding = source.bind_property("obj", owner, "obj", GLib::BindingFlags::SYNC_CREATE)
    binding.unbind

    # Drop every reference except `owner`.
    source.obj = nil
    source  = nil
    leaf    = nil
    binding = nil

    GC.start
    GC.start(full_mark: true, immediate_sweep: true)

    owner.freeze # keep `owner` reachable across the check
    if (leaf_ref.weakref_alive? rescue false)
      puts "PASS: object-valued property wrapper retained across GC"
    else
      puts "FAIL: object-valued property wrapper was garbage-collected"
    end
```
Run: `ruby repro.rb`

## Expected

`PASS` -- an object value held by a property stays valid for the owner's lifetime.

## Actual

`FAIL` -- the value's wrapper is collected after GC. In a real program a subsequent read of the property segfaults or raises `GLib::NoPropertyError: No such property` (as in #1688).

## Root cause

Three pieces of `glib2/ext/glib2/rbgobj_object.c` (4.3.6) interlock:

1. `gobj_mark()` deliberately does **not** mark object-valued properties of classes defined by Ruby -- it cannot call a Ruby getter during GC (lines 289-301). The comment states the assumption:

       /* ... we don't need to mark properties here because properties
          must be referred from a GObject defined by Ruby. */

   So the mark phase contributes no root; the design relies on those values being rooted on the Ruby side.

2. The Ruby-level accessors honor that. `rg_set_property` (`Object#set_property`, bound at line 1107) ends with `G_CHILD_SET(self, rb_intern(name), val)` (line 637), and `rg_get_property` does the same (line 669). `G_CHILD_SET` is `rb_ivar_set`, so the value is rooted as a hidden ivar on the owner.

3. The `set_property` vfunc, `set_prop_func` (line 959), does not. It marshals to the Ruby setter and returns without rooting the value:

       rb_funcall(GOBJ2RVAL(object), ruby_setter, 1, GVAL2RVAL(value));  // line 977

   This vfunc is the path used for property bindings (`bind_property`, line 1123) and `g_object_set` from C. (Construct-time object properties on Ruby-defined classes are independently blocked by an existing "wrapper already exists" guard, so they are out of scope here.)

When an object value reaches a Ruby-defined object through this vfunc and the Ruby setter does not itself retain the wrapper, the wrapper is rooted nowhere: not by `gobj_mark` (1) and not by an ivar (3). The next GC reclaims it; the underlying GObject is still alive (the owner holds a ref), so a later access resolves a stale/recreated wrapper -> crash or `NoPropertyError`.

## Suggested fix

Root the value as a hidden ivar on the owner from inside the vfunc, gated on `G_TYPE_IS_OBJECT` -- mirroring the gate already used in `gobj_mark` (line 287) and the retention already done by the Ruby accessors (lines 637/669):
```
    --- a/glib2/ext/glib2/rbgobj_object.c
    +++ b/glib2/ext/glib2/rbgobj_object.c
    @@ -974,7 +974,14 @@
             g_free(name);
         }
     
    -    rb_funcall(GOBJ2RVAL(object), ruby_setter, 1, GVAL2RVAL(value));
    +    {
    +        VALUE rb_object = GOBJ2RVAL(object);
    +        VALUE rb_value = GVAL2RVAL(value);
    +        rb_funcall(rb_object, ruby_setter, 1, rb_value);
    +        if (G_TYPE_IS_OBJECT(G_PARAM_SPEC_VALUE_TYPE(pspec))) {
    +            G_CHILD_SET(rb_object, rb_intern(g_param_spec_get_name(pspec)), rb_value);
    +        }
    +    }
     }
```
With this change the reproducer prints `PASS`. The locals ensure the rooted VALUE is the same one passed to the setter; non-object value types are untouched (no behavior change for String/Integer/Boolean properties); and `Object#set_property` is unaffected (already rooted at line 637). I'm happy to open a PR with this change plus the reproducer as a regression test.