### PR TITLE
fix(gobject-introspection): GC crashes in boxed/object class converters

### DIFF
--- a/gobject-introspection/ext/gobject-introspection/rb-gi-loader.c
+++ b/gobject-introspection/ext/gobject-introspection/rb-gi-loader.c
@@ -22,9 +22,6 @@
 
 #define RG_TARGET_NAMESPACE rb_cGILoader
 
-static const gchar *boxed_class_converters_name = "@@boxed_class_converters";
-static const gchar *object_class_converters_name = "@@object_class_converters";
-
 static VALUE
 rg_s_define_class(int argc, VALUE *argv, G_GNUC_UNUSED VALUE klass)
 {
@@ -192,7 +189,6 @@ rg_s_implement_virtual_function(G_GNUC_UNUSED VALUE klass,
 
 typedef struct {
     GType type;
-    VALUE rb_converters;
     VALUE rb_converter;
 } BoxedInstance2RObjData;
 
@@ -200,7 +196,6 @@ static void
 boxed_class_converter_free(gpointer user_data)
 {
     BoxedInstance2RObjData *data = user_data;
-    rb_ary_delete(data->rb_converters, data->rb_converter);
     g_free(data);
 }
 
@@ -224,7 +219,6 @@ rg_s_register_boxed_class_converter(VALUE klass, VALUE rb_gtype)
 {
     RGConvertTable table;
     BoxedInstance2RObjData *data;
-    VALUE boxed_class_converters;
 
     memset(&table, 0, sizeof(RGConvertTable));
     table.type = rbgobj_gtype_from_ruby(rb_gtype);
@@ -234,8 +228,14 @@ rg_s_register_boxed_class_converter(VALUE klass, VALUE rb_gtype)
     data = g_new(BoxedInstance2RObjData, 1);
     data->type = table.type;
     data->rb_converter = rb_block_proc();
-    boxed_class_converters = rb_cv_get(klass, boxed_class_converters_name);
-    rb_ary_push(boxed_class_converters, data->rb_converter);
+    /* Pin the converter Proc as a permanent GC root. It was previously
+     * cached as a bare VALUE in this g_malloc'd struct, invisible to the
+     * GC: GC.compact could relocate the Proc without updating the cached
+     * pointer, leaving the next conversion to call rb_funcall on a
+     * dangling reference. These converters are process-lifetime singletons
+     * (a handful, registered once per GType), so pinning is the correct
+     * lifetime. */
+    rb_gc_register_mark_object(data->rb_converter);
     table.user_data = data;
     table.notify = boxed_class_converter_free;
 
@@ -246,7 +246,6 @@ rg_s_register_boxed_class_converter(VALUE klass, VALUE rb_gtype)
 
 typedef struct {
     GType type;
-    VALUE rb_converters;
     VALUE rb_converter;
 } ObjectInstance2RObjData;
 
@@ -254,7 +253,6 @@ static void
 object_class_converter_free(gpointer user_data)
 {
     ObjectInstance2RObjData *data = user_data;
-    rb_ary_delete(data->rb_converters, data->rb_converter);
     g_free(data);
 }
 
@@ -292,7 +290,6 @@ rg_s_register_object_class_converter(VALUE klass, VALUE rb_gtype)
 {
     RGConvertTable table;
     ObjectInstance2RObjData *data;
-    VALUE object_class_converters;
 
     memset(&table, 0, sizeof(RGConvertTable));
     table.type = rbgobj_gtype_from_ruby(rb_gtype);
@@ -302,8 +299,8 @@ rg_s_register_object_class_converter(VALUE klass, VALUE rb_gtype)
     data = g_new(ObjectInstance2RObjData, 1);
     data->type = table.type;
     data->rb_converter = rb_block_proc();
-    object_class_converters = rb_cv_get(klass, object_class_converters_name);
-    rb_ary_push(object_class_converters, data->rb_converter);
+    /* See rg_s_register_boxed_class_converter. */
+    rb_gc_register_mark_object(data->rb_converter);
     table.user_data = data;
     table.notify = object_class_converter_free;
 
@@ -376,9 +373,6 @@ rb_gi_loader_init(VALUE rb_mGI)
     VALUE RG_TARGET_NAMESPACE;
 
     RG_TARGET_NAMESPACE = rb_define_class_under(rb_mGI, "Loader", rb_cObject);
-
-    rb_cv_set(RG_TARGET_NAMESPACE, boxed_class_converters_name, rb_ary_new());
-    rb_cv_set(RG_TARGET_NAMESPACE, object_class_converters_name, rb_ary_new());
 
     RG_DEF_SMETHOD(define_class, -1);
     RG_DEF_SMETHOD(define_interface, 3);

--- a/gobject-introspection/ext/gobject-introspection/rb-gi-loader.c
+++ b/gobject-introspection/ext/gobject-introspection/rb-gi-loader.c
@@ -196,6 +196,7 @@ static void
 boxed_class_converter_free(gpointer user_data)
 {
     BoxedInstance2RObjData *data = user_data;
+    rb_gc_unregister_address(&data->rb_converter);
     g_free(data);
 }
 
@@ -228,14 +229,14 @@ rg_s_register_boxed_class_converter(VALUE klass, VALUE rb_gtype)
     data = g_new(BoxedInstance2RObjData, 1);
     data->type = table.type;
     data->rb_converter = rb_block_proc();
-    /* Pin the converter Proc as a permanent GC root. It was previously
-     * cached as a bare VALUE in this g_malloc'd struct, invisible to the
-     * GC: GC.compact could relocate the Proc without updating the cached
-     * pointer, leaving the next conversion to call rb_funcall on a
-     * dangling reference. These converters are process-lifetime singletons
-     * (a handful, registered once per GType), so pinning is the correct
-     * lifetime. */
-    rb_gc_register_mark_object(data->rb_converter);
+    /* Root the converter Proc via the address of its storage, tied to this
+     * entry's lifetime. It was previously cached as a bare VALUE in this
+     * g_malloc'd struct, invisible to the GC, so GC.compact could invalidate
+     * the cached reference and the next conversion would call rb_funcall on
+     * stale memory. rb_gc_register_address keeps the reference valid across
+     * GC and compaction; the matching rb_gc_unregister_address in the free
+     * callback releases the Proc when this converter entry is replaced. */
+    rb_gc_register_address(&data->rb_converter);
     table.user_data = data;
     table.notify = boxed_class_converter_free;
 
@@ -253,6 +254,7 @@ static void
 object_class_converter_free(gpointer user_data)
 {
     ObjectInstance2RObjData *data = user_data;
+    rb_gc_unregister_address(&data->rb_converter);
     g_free(data);
 }
 
@@ -300,7 +302,7 @@ rg_s_register_object_class_converter(VALUE klass, VALUE rb_gtype)
     data->type = table.type;
     data->rb_converter = rb_block_proc();
     /* See rg_s_register_boxed_class_converter. */
-    rb_gc_register_mark_object(data->rb_converter);
+    rb_gc_register_address(&data->rb_converter);
     table.user_data = data;
     table.notify = object_class_converter_free;
 


### PR DESCRIPTION
## Summary

`register_boxed_class_converter` / `register_object_class_converter` (`rb-gi-loader.c`) cache the registered converter `Proc` as a bare `VALUE` inside a plain `g_malloc`'d struct (`BoxedInstance2RObjData` / `ObjectInstance2RObjData`) -- outside Ruby's GC-visible object graph, with no mark and no compaction hook. Two distinct crashes follow from that one design choice:

1. **Deterministic** -- re-registering a converter for a GType crashes. The struct field `rb_converters` is read by the free callback but is never assigned by the register function, and the struct is allocated with `g_new` (which, unlike `g_new0`, does not zero). Re-registration replaces the conversion-table entry, which synchronously fires the destroy-notify on the *old* entry, and that callback dereferences the uninitialized field.

2. **Non-deterministic (GC.compact)** -- the cached `data->rb_converter` copy is invisible to the moving GC, so `GC.compact` can invalidate the cached reference. The next boxed/object conversion through that converter then calls `rb_funcall` on stale memory and crashes (SIGBUS/SIGSEGV), deep in a real signal-marshaling callback.

The fix roots each converter `Proc` through the address of its storage, tied to the converter entry's lifetime, and removes the dead machinery both crashes lived in.

## Crash 1: root cause (deterministic)

    // rb-gi-loader.c
    typedef struct {
        GType type;
        VALUE rb_converters;   // read by the free callback, never assigned
        VALUE rb_converter;
    } BoxedInstance2RObjData;

    static void
    boxed_class_converter_free(gpointer user_data)
    {
        BoxedInstance2RObjData *data = user_data;
        rb_ary_delete(data->rb_converters, data->rb_converter);  // uninitialized field
        g_free(data);
    }

    static VALUE
    rg_s_register_boxed_class_converter(VALUE klass, VALUE rb_gtype)
    {
        ...
        data = g_new(BoxedInstance2RObjData, 1);                 // g_new, not g_new0
        data->type = table.type;
        data->rb_converter = rb_block_proc();
        boxed_class_converters = rb_cv_get(klass, boxed_class_converters_name);
        rb_ary_push(boxed_class_converters, data->rb_converter); // pushes to a LOCAL, not data->rb_converters
        ...
        rbgobj_convert_define(&table);
    }

`data->rb_converters` is never written; `data->rb_converter` is protected from collection via the `@@boxed_class_converters` class-variable array, but the free callback tries to remove it from the uninitialized `rb_converters` field instead. On re-registration, `rbgobj_convert_define` -> `g_hash_table_insert` replaces the entry and invokes `boxed_class_converter_free` on the old value, which calls `rb_ary_delete` on garbage -> SIGSEGV. The object converter (`ObjectInstance2RObjData`) is identical.

This is not fixable by switching `g_new` to `g_new0` alone: a zeroed field is `Qfalse`, so `rb_ary_delete(Qfalse, ...)` would raise `TypeError` rather than crash -- still wrong, and it does nothing for crash 2.

## Fix

Root each converter `Proc` via `rb_gc_register_address` on the address of its storage, and release it with `rb_gc_unregister_address` in the free callback. This keeps the cached reference valid across GC and compaction (fixing crash 2), and ties the `Proc`'s lifetime to the converter-table entry: when `rbgobj_convert_define` replaces an entry, the old entry's free callback unregisters and releases its `Proc`. With the `Proc` rooted this way, the whole protection-array + uninitialized-field mechanism is unnecessary and is removed (fixing crash 1).

Key change (both converters):

    @@ rg_s_register_boxed_class_converter
         data = g_new(BoxedInstance2RObjData, 1);
         data->type = table.type;
         data->rb_converter = rb_block_proc();
    -    boxed_class_converters = rb_cv_get(klass, boxed_class_converters_name);
    -    rb_ary_push(boxed_class_converters, data->rb_converter);
    +    /* Root the converter Proc via the address of its storage, tied to this
    +     * entry's lifetime. It was previously cached as a bare VALUE in this
    +     * g_malloc'd struct, invisible to the GC, so GC.compact could invalidate
    +     * the cached reference and the next conversion would call rb_funcall on
    +     * stale memory. rb_gc_register_address keeps the reference valid across
    +     * GC and compaction; the matching rb_gc_unregister_address in the free
    +     * callback releases the Proc when this converter entry is replaced. */
    +    rb_gc_register_address(&data->rb_converter);
         table.user_data = data;
         table.notify = boxed_class_converter_free;

    @@ boxed_class_converter_free
         BoxedInstance2RObjData *data = user_data;
    -    rb_ary_delete(data->rb_converters, data->rb_converter);
    +    rb_gc_unregister_address(&data->rb_converter);
         g_free(data);

The full patch also removes what those lines orphaned: the now-unused `rb_converters` field from both structs, the two unused register locals, the `@@boxed_class_converters` / `@@object_class_converters` class variables and their initialization, and the two `*_class_converters_name` declarations. (The object converter mirrors the boxed one; full patch attached.)

`rb_gc_unregister_address` runs in the same context the removed `rb_ary_delete` did (the destroy-notify invoked from `rbgobj_convert_define`), so it introduces no new "Ruby C API in a callback" concern; and it runs before `g_free(data)`, so the registered address is never left pointing at freed memory.

## Behavior / compatibility

No API change -- `register_boxed_class_converter` / `register_object_class_converter` are still exported and behave the same for callers. Re-registering a converter for the same GType now releases the previous `Proc` (via the old entry's free callback) instead of crashing -- no leak. The removed `@@..._class_converters` class variables were an internal GC-protection detail with no readers (C or Ruby side).

Alternative considered: `rb_gc_register_mark_object(data->rb_converter)` is a simpler one-liner, but it registers a permanent, non-releasable root -- so a re-registered converter would leak its previous `Proc` for the process lifetime (`rb_gc_register_mark_object` has no unregister counterpart). Tying the root to the entry lifetime via register/unregister avoids that.

## Testing

Self-contained reproducer (Pango-only -- the minimal affected consumer that needs no display), included below. It re-runs Pango's converter registration in a forked child and reports PASS/FAIL from the child's exit status; because it re-registers, it also exercises the release path (the replaced entry's free callback runs `rb_gc_unregister_address`):

```ruby
require "pango"

# Regression test for the boxed/object class-converter GC crashes.
#
# Pango is the minimal affected consumer that needs no display: `require "pango"`
# registers its attribute converters once, and re-invoking that registration a
# second time replaces the conversion-table entry -- which, on the unpatched gem,
# frees the old entry and dereferences its uninitialized `rb_converters` field
# (crash 1). The crash is a real SIGSEGV, not a rescuable exception, so the risky
# call runs in a forked child; the parent reports PASS/FAIL from its exit status.
# (Reproduces crash 1 deterministically; crash 2, the GC.compact use-after-free,
# is not reliably reproducible in a short script and is not attempted here.)

def run_child
  # First registration happened during `require "pango"` (its loader's
  # convert_attribute_classes runs at load). This second call replaces that
  # entry -- on the broken gem the conversion table frees the old entry
  # synchronously as part of the replacement, which crashes right here.
  Pango::Loader.new(Pango).send(:convert_attribute_classes)

  # If we get here the converter survived re-registration; confirm it still
  # resolves boxed instances to the right Ruby subclass.
  attr_list, = Pango.parse_markup("<b>hello</b> world")
  klass = nil
  attr_list.each { |iter| iter.attrs.each { |a| klass = a.class } }
  exit!(klass == Pango::AttrWeight ? 0 : 2) # exit! skips finalizers; 0 = pass, 2 = wrong result
end

pid = fork { run_child }
_, status = Process.wait2(pid)

if status.success?
  puts "PASS: re-registering a boxed class converter did not crash, and it still resolves correctly"
elsif status.signaled?
  sig = status.termsig
  puts "FAIL: re-registering a boxed class converter crashed with signal #{sig} (#{Signal.signame(sig)}) -- " \
       "the free callback on the replaced entry dereferenced an uninitialized/stale field"
else
  puts "FAIL: re-registration did not crash, but the converter now resolves the wrong class " \
       "(exit status #{status.exitstatus})"
end

exit(status.success? ? 0 : 1)
```

On the stock gem this prints `FAIL: ... crashed with signal ...`; with the patch it prints `PASS: ... did not crash, and it still resolves correctly`.

Crash 1 reproduces deterministically (the C backtrace is `rb_ary_delete` <- `boxed_class_converter_free` <- `g_hash_table_insert` <- `rbgobj_convert_define`). The `rb_gc_register_address` mechanism was separately verified in isolation (a minimal C extension confirming a VALUE stored in a `malloc`'d struct and rooted via `rb_gc_register_address` survives GC, stays valid across `GC.compact`, and unregisters/frees cleanly). Crash 2 is confirmed from the source structure and two real-world long-running-session crash logs; it is not reliably reproducible in a short script, so the test does not attempt it -- but both crashes share this root cause and this fix.