### PR TITLE
gstreamer: Initialize MemoryView's item_desc

### DIFF
--- a/gstreamer/ext/gstreamer/rbgst-sample.c
+++ b/gstreamer/ext/gstreamer/rbgst-sample.c
@@ -309,6 +309,8 @@ rg_gst_memory_view_init_from_audio(VALUE obj, rb_memory_view_t *view, int flags,
     view->ndim = 2;
     view->shape = shape;
     view->strides = strides;
+    view->item_desc.length = 0;
+    view->item_desc.components = NULL;
     view->sub_offsets = NULL;
 #if RUBY_API_VERSION_MAJOR == 3 && RUBY_API_VERSION_MINOR == 0
     *((void **)&view->private) = private_data;


### PR DESCRIPTION
Hello,

Current implementation (I did) lacks the initailization of MemoryView's `item_desc` member that sometimes leads wrong value of `item_desc.length`. This pull request fixes it.

Thank you.
