### PR TITLE
gstreamer: Make more strict the check of MemoryView's column-major request flag

### DIFF
--- a/gstreamer/ext/gstreamer/rbgst-sample.c
+++ b/gstreamer/ext/gstreamer/rbgst-sample.c
@@ -324,10 +324,12 @@ rg_gst_sample_get(VALUE obj, rb_memory_view_t *view, int flags)
 {
     GstSample *sample;
     GstCaps *caps;
+    bool is_row_major_requested;
     bool is_column_major_requested;
 
+    is_row_major_requested = flags & RUBY_MEMORY_VIEW_ROW_MAJOR;
     is_column_major_requested = flags & RUBY_MEMORY_VIEW_COLUMN_MAJOR;
-    if (is_column_major_requested) {
+    if (is_column_major_requested && !is_row_major_requested) {
         // TODO: column-major support
         rb_warn("Gst::Sample: currently column-major is not supported");
 


### PR DESCRIPTION
Hello,

This pull request makes the check of MemoryView's flags including `RUBY_MEMORY_VIEW_COLUMN_MAJOR` more strict. When `RUBY_MEMORY_VIEW_ANY_CONTIGUOUS` flag is passed to to `rb_memory_view_get()` with `Gst::Sample`, it occurs wrong check.

Thanks.
