### PR TITLE
glib2: add support for girepository-2

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,6 +26,7 @@ jobs:
           - ubuntu-22.04
           - ubuntu-24.04
           - ubuntu-26.04
+          - ubuntu-26.04-girepository
         include:
           - service: apache-arrow
             timeout-minutes: 60

--- a/compose.yaml
+++ b/compose.yaml
@@ -322,3 +322,18 @@ services:
       GITHUB_ACTIONS:
     command:
       /ruby-gnome/dockerfiles/run-test.sh
+
+  ubuntu-26.04-girepository:
+    image: ghcr.io/${GITHUB_REPOSITORY}:ubuntu-26.04
+    build:
+      cache_from:
+        - ghcr.io/${GITHUB_REPOSITORY}:ubuntu-26.04
+      context: .
+      dockerfile: dockerfiles/ubuntu-26.04.dockerfile
+    volumes:
+      - .:/ruby-gnome:delegated
+    environment:
+      GITHUB_ACTIONS:
+      RUBY_GNOME_GLIB2_GIREPOSITORY_ENABLE: "yes"
+    command:
+      /ruby-gnome/dockerfiles/run-test.sh

--- a/dockerfiles/run-test.sh
+++ b/dockerfiles/run-test.sh
@@ -46,6 +46,10 @@ echo "::endgroup::"
 MAKEFLAGS="-j$(nproc)" rake -f /ruby-gnome/Rakefile gem:install
 
 if [ "${RUBY_GNOME_TEST_ENABLE:-yes}" != "no" ]; then
+  if [ "${RUBY_GNOME_GLIB2_GIREPOSITORY_ENABLE:-no}" = "yes" ] && \
+       apt --version; then
+    sudo apt install -y -V gir1.2-glib-2.0-dev
+  fi
   export RUBY_GNOME_BUILD_DIR="${PWD}"
   if type dbus-run-session > /dev/null 2>&1 &&
       type xvfb-run > /dev/null 2>&1; then

--- a/glib2/ext/glib2/extconf.rb
+++ b/glib2/ext/glib2/extconf.rb
@@ -1,4 +1,4 @@
-# Copyright (C) 2002-2025  Ruby-GNOME Project Team
+# Copyright (C) 2002-2026  Ruby-GNOME Project Team
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -39,6 +39,16 @@ unless required_pkg_config_package([package_id, 2, 56, 0],
   exit(false)
 end
 PKGConfig.have_package('gthread-2.0')
+if ENV["RUBY_GNOME_GLIB2_GIREPOSITORY_ENABLE"] == "yes"
+  have_girepository =
+    required_pkg_config_package(["girepository-2.0", 2, 80, 0],
+                                debian: "libgirepository-2.0-dev")
+else
+  have_girepository = false
+end
+if have_girepository
+  $defs << "-DHAVE_GIREPOSITORY"
+end
 
 have_header("unistd.h")
 have_header("io.h")
@@ -91,6 +101,18 @@ glib_mkenums(enum_types_prefix,
              "G_TYPE_",
              [],
              preamble: "#include \"rbgprivate.h\"")
+
+if have_girepository
+  girepository_headers = include_paths.split.inject([]) do |result, path|
+    result + Dir.glob(File.join(path.sub(/^-I/, ""), "girepository", "*.h"))
+  end
+  glib_mkenums("gi-enum-types",
+               girepository_headers,
+               "GI_TYPE_",
+               [],
+               id_prefix: "GI",
+               preamble: "#include <girepository/girepository.h>")
+end
 
 $defs << "-DRUBY_GLIB2_COMPILATION"
 

--- a/glib2/ext/glib2/rbgi-base-info.c
+++ b/glib2/ext/glib2/rbgi-base-info.c
@@ -1,0 +1,164 @@
+/* -*- c-file-style: "ruby"; indent-tabs-mode: nil -*- */
+/*
+ *  Copyright (C) 2012-2026  Ruby-GNOME Project Team
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ *  MA  02110-1301  USA
+ */
+
+#ifdef HAVE_GIREPOSITORY
+#include "rbgi-private.h"
+
+#define RG_TARGET_NAMESPACE rb_cGLibBaseInfo
+static VALUE RG_TARGET_NAMESPACE;
+#define SELF(self) RVAL2GI_BASE_INFO(self)
+
+static void
+rbgi_base_info_free(void *data)
+{
+    GIBaseInfoStack *info = data;
+    gi_base_info_unref(info);
+}
+
+static const rb_data_type_t rbgi_base_info_type = {
+    "GLib::BaseInfo",
+    {
+        NULL,
+        rbgi_base_info_free,
+        NULL,
+        NULL,
+    },
+    &rbg_glib_instantiatable_type,
+    NULL,
+    RUBY_TYPED_FREE_IMMEDIATELY |
+    RUBY_TYPED_WB_PROTECTED |
+    RUBY_TYPED_FROZEN_SHAREABLE,
+};
+
+static VALUE
+rbgi_base_info_alloc_func(VALUE klass)
+{
+    return TypedData_Wrap_Struct(klass,
+                                 &rbgi_base_info_type,
+                                 NULL);
+}
+
+VALUE
+rbgi_base_info_to_ruby(GIBaseInfo *info)
+{
+    if (!info) {
+        return Qnil;
+    }
+
+    gi_base_info_ref(info);
+    return TypedData_Wrap_Struct(RG_TARGET_NAMESPACE,
+                                 &rbgi_base_info_type,
+                                 info);
+}
+
+VALUE
+rbgi_base_info_to_ruby_take(GIBaseInfo *info)
+{
+    if (!info) {
+        return Qnil;
+    }
+
+    return TypedData_Wrap_Struct(RG_TARGET_NAMESPACE,
+                                 &rbgi_base_info_type,
+                                 info);
+}
+
+GIBaseInfo *
+rbgi_base_info_from_ruby(VALUE rb_info)
+{
+    GIBaseInfo *info;
+    TypedData_Get_Struct(rb_info,
+                         GIBaseInfo,
+                         &rbgi_base_info_type,
+                         info);
+    return info;
+}
+
+static VALUE
+rg_name(VALUE self)
+{
+    GIBaseInfo *info;
+
+    info = SELF(self);
+    return CSTR2RVAL(gi_base_info_get_name(info));
+}
+
+static VALUE
+rg_namespace(VALUE self)
+{
+    GIBaseInfo *info;
+
+    info = SELF(self);
+    return CSTR2RVAL(gi_base_info_get_namespace(info));
+}
+
+static VALUE
+rg_container(VALUE self)
+{
+    GIBaseInfo *info;
+
+    info = SELF(self);
+    return rbgi_base_info_to_ruby(gi_base_info_get_container(info));
+}
+
+static VALUE
+rg_operator_aref(VALUE self, VALUE name)
+{
+    GIBaseInfo *info;
+
+    info = SELF(self);
+    return CSTR2RVAL(gi_base_info_get_attribute(info, RVAL2CSTR(name)));
+}
+
+static VALUE
+rg_each(VALUE self)
+{
+    GIAttributeIter iter = {0, };
+    GIBaseInfo *info;
+    const gchar *name, *value;
+
+    RETURN_ENUMERATOR(self, 0, NULL);
+
+    info = SELF(self);
+    while (gi_base_info_iterate_attributes(info, &iter, &name, &value)) {
+	VALUE rb_name, rb_value;
+	rb_name  = CSTR2RVAL(name);
+	rb_value = CSTR2RVAL(value);
+	rb_yield(rb_ary_new3(2, rb_name, rb_value));
+    }
+
+    return Qnil;
+}
+
+void
+rbgi_base_info_init(VALUE rb_mGLib)
+{
+    RG_TARGET_NAMESPACE = G_DEF_CLASS(GI_TYPE_BASE_INFO, "BaseInfo", rb_mGLib);
+    rb_define_alloc_func(RG_TARGET_NAMESPACE, rbgi_base_info_alloc_func);
+
+    rb_include_module(RG_TARGET_NAMESPACE, rb_mEnumerable);
+
+    RG_DEF_METHOD(name, 0);
+    RG_DEF_METHOD(namespace, 0);
+    RG_DEF_METHOD(container, 0);
+    RG_DEF_METHOD_OPERATOR("[]", aref, 1);
+    RG_DEF_METHOD(each, 0);
+}
+#endif

--- a/glib2/ext/glib2/rbgi-conversions.h
+++ b/glib2/ext/glib2/rbgi-conversions.h
@@ -1,0 +1,32 @@
+/* -*- c-file-style: "ruby"; indent-tabs-mode: nil -*- */
+/*
+ *  Copyright (C) 2012-2026  Ruby-GNOME Project Team
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ *  MA  02110-1301  USA
+ */
+
+#pragma once
+
+#define RVAL2GI_REPOSITORY_LOAD_FLAGS(rb_flags) \
+    (RVAL2GFLAGS(rb_flags, GI_TYPE_REPOSITORY_LOAD_FLAGS))
+
+GIBaseInfo *rbgi_base_info_from_ruby(VALUE rb_info);
+VALUE rbgi_base_info_to_ruby(GIBaseInfo *info);
+VALUE rbgi_base_info_to_ruby_take(GIBaseInfo *info);
+
+#define RVAL2GI_BASE_INFO(rb_info)   rbgi_base_info_from_ruby(rb_info)
+#define GI_BASE_INFO2RVAL(info)      rbgi_base_info_to_ruby(info)
+#define GI_BASE_INFO2RVAL_TAKE(info) rbgi_base_info_to_ruby_take(info)

--- a/glib2/ext/glib2/rbgi-private.h
+++ b/glib2/ext/glib2/rbgi-private.h
@@ -1,0 +1,33 @@
+/* -*- c-file-style: "ruby"; indent-tabs-mode: nil -*- */
+/*
+ *  Copyright (C) 2012-2026  Ruby-GNOME Project Team
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ *  MA  02110-1301  USA
+ */
+
+#pragma once
+
+#include "rbgprivate.h"
+#include "rbglib2conversions.h"
+
+#include <girepository/girepository.h>
+#include <girepository/girffi.h>
+
+#include "gi-enum-types.h"
+#include "rbgi-conversions.h"
+
+G_GNUC_INTERNAL void rbgi_base_info_init(VALUE mGLib);
+G_GNUC_INTERNAL void rbgi_repository_init(VALUE mGLib);

--- a/glib2/ext/glib2/rbgi-repository.c
+++ b/glib2/ext/glib2/rbgi-repository.c
@@ -1,0 +1,277 @@
+/* -*- c-file-style: "ruby"; indent-tabs-mode: nil -*- */
+/*
+ *  Copyright (C) 2012-2026  Ruby-GNOME Project Team
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ *  MA  02110-1301  USA
+ */
+
+#ifdef HAVE_GIREPOSITORY
+#include "rbgi-private.h"
+
+#define RG_TARGET_NAMESPACE rb_cGLibRepository
+static VALUE RG_TARGET_NAMESPACE;
+#define SELF(self) RVAL2GOBJ(self)
+
+#if GLIB_CHECK_VERSION(2, 86, 0)
+/* Returns the singleton process-global default
+ * GLib::Repository. It is not currently supported to have
+ * multiple repositories in a particular process, but this function is provided
+ * in the unlikely eventuality that it would become possible, and as a
+ * convenience for higher level language bindings to conform to the GObject
+ * method call conventions.
+ *
+ * @return [GLib::Repository] The global singleton
+ *         GLib::Repository.
+ */
+static VALUE
+rg_s_default(G_GNUC_UNUSED VALUE klass)
+{
+    return GOBJ2RVAL_UNREF(gi_repository_dup_default());
+}
+#endif
+
+static VALUE
+rg_prepend_search_path(VALUE self, VALUE rb_path)
+{
+    gi_repository_prepend_search_path(SELF(self), RVAL2CSTR(rb_path));
+    return self;
+}
+
+static VALUE
+rg_search_path(VALUE self)
+{
+    GIRepository *repository = SELF(self);
+    size_t n_paths;
+    const gchar *const *paths =
+        gi_repository_get_search_path(repository, &n_paths);
+    VALUE rb_paths = rb_ary_new_capa(n_paths);
+    for (size_t i = 0; i < n_paths; i++) {
+        rb_ary_push(rb_paths, CSTR2RVAL(paths[i]));
+    }
+    return rb_paths;
+}
+
+/* Force the namespace to be loaded if it isn't already. If namespace is not
+ * loaded, this function will search for a ".typelib" file using the repository
+ * search path. In addition, a version of namespace may be specified. If version
+ * is not specified, the latest will be used.
+ *
+ * @param [String] namespace The namespace to load
+ * @param [String, nil] version An optional version
+ */
+static VALUE
+rg_require(int argc, VALUE *argv, VALUE self)
+{
+    VALUE rb_namespace, rb_version, rb_flags;
+    const gchar *namespace_, *version;
+    GIRepositoryLoadFlags flags = 0;
+    GError *error = NULL;
+
+    rb_scan_args(argc, argv, "12", &rb_namespace, &rb_version, &rb_flags);
+
+    namespace_ = RVAL2CSTR(rb_namespace);
+    version = RVAL2CSTR_ACCEPT_NIL(rb_version);
+    if (!NIL_P(rb_flags)) {
+        flags = RVAL2GI_REPOSITORY_LOAD_FLAGS(rb_flags);
+    }
+
+    gi_repository_require(SELF(self), namespace_, version, flags, &error);
+    if (error) {
+        RG_RAISE_ERROR(error);
+    }
+
+    return Qnil;
+}
+
+
+/* Return an array of all (transitive) versioned dependencies for namespace.
+ * Returned strings are of the form "namespace-version".
+ * Note: namespace must have already been loaded using a function such as
+ * GLib::Repository.require() before calling this method.
+ *
+ * @param [String] namespace The namespace to get the dependencies for.
+ *
+ * @return [Array<String>] The dependencies.
+ */
+static VALUE
+rg_get_dependencies(VALUE self, VALUE rb_namespace)
+{
+    GIRepository *repository = SELF(self);
+    const gchar *namespace_ = RVAL2CSTR(rb_namespace);
+    size_t n_dependencies;
+    gchar **dependencies = gi_repository_get_dependencies(repository, namespace_, &n_dependencies);
+    if (!dependencies) {
+        return Qnil;
+    }
+
+    VALUE rb_dependencies = rb_ary_new_capa(n_dependencies);
+    for (size_t i = 0; dependencies[i]; i++) {
+        rb_ary_push(rb_dependencies, CSTR2RVAL_FREE(dependencies[i]));
+    }
+    g_free(dependencies);
+
+    return rb_dependencies;
+}
+
+
+/* Return the list of currently loaded namespaces.
+ *
+ * @return [Array<String>] The loaded namespaces.
+ */
+static VALUE
+rg_loaded_namespaces(VALUE self)
+{
+    GIRepository *repository = SELF(self);
+    size_t n_namespaces;
+    gchar **namespaces = gi_repository_get_loaded_namespaces(repository, &n_namespaces);
+    if (!namespaces) {
+        return Qnil;
+    }
+    VALUE rb_namespaces = rb_ary_new_capa(n_namespaces);
+    for (size_t i = 0; namespaces[i]; i++) {
+        rb_ary_push(rb_namespaces, CSTR2RVAL_FREE(namespaces[i]));
+    }
+    g_free(namespaces);
+
+    return rb_namespaces;
+}
+
+
+/* This method returns the number of metadata entries in given namespace. The
+ * namespace must have already been loaded before calling this function.
+ *
+ * @param [String] namespace The namespace to fetch the entries from.
+ *
+ * @return [Integer] The number of metadata entries.
+ */
+static VALUE
+rg_get_n_infos(VALUE self, VALUE rb_namespace)
+{
+    const gchar *namespace_;
+    gint n_infos;
+
+    namespace_ = RVAL2CSTR(rb_namespace);
+    n_infos = gi_repository_get_n_infos(SELF(self), namespace_);
+
+    return INT2NUM(n_infos);
+}
+
+
+/* This method returns a particular metadata entry in the given namespace. The
+ *  namespace must have already been loaded before calling this function. See
+ *  GLib::Repository#get_n_infos() to find the maximum number
+ *  of entries.
+ *
+ * @param [String] namespace The namespace to fetch the metadata entry from.
+ * @param [Fixnum] index The index of the entry.
+ *
+ * @return [GLib::BaseInfo] The metadata entry.
+ */
+static VALUE
+rg_get_info(VALUE self, VALUE rb_namespace, VALUE rb_n)
+{
+    GIRepository *repository;
+    const gchar *namespace_;
+    gint n;
+    GIBaseInfo *info;
+
+    repository = SELF(self);
+    namespace_ = RVAL2CSTR(rb_namespace);
+    n = NUM2INT(rb_n);
+    info = gi_repository_get_info(repository, namespace_, n);
+    return GI_BASE_INFO2RVAL_TAKE(info);
+}
+
+
+/* This method searches for a particular type or name. If only one argument is
+ * given, it is interpreted as a gtype and all loaded namespaces are searched
+ * for it. If two arguments are given the first is a particular namespace and
+ * the second the name of an entry to search for.
+ *
+ * @overload find(type)
+ *
+ * @param [String] type The type to search for.
+ *
+ * @return [GLib::BaseInfo] The metadata entry.
+ *
+ *
+ * @overload find(namespace, type)
+ *
+ * @param [String] namespace The namespace to search in.
+ *
+ * @param [String] type The type to search for.
+ *
+ * @return [GLib::BaseInfo] The metadata entry.
+ */
+
+static VALUE
+rg_find(int argc, VALUE *argv, VALUE self)
+{
+    GIBaseInfo *info;
+
+    if (argc == 1) {
+        VALUE rb_gtype;
+        GType gtype;
+        rb_gtype = argv[0];
+        gtype = rbgobj_gtype_from_ruby(rb_gtype);
+        info = gi_repository_find_by_gtype(SELF(self), gtype);
+    } else {
+        VALUE rb_namespace, rb_name;
+        const gchar *namespace_, *name;
+
+        rb_scan_args(argc, argv, "2", &rb_namespace, &rb_name);
+        namespace_ = RVAL2CSTR(rb_namespace);
+        name = RVAL2CSTR(rb_name);
+        info = gi_repository_find_by_name(SELF(self), namespace_, name);
+    }
+
+    return GI_BASE_INFO2RVAL(info);
+}
+
+static VALUE
+rg_get_version(VALUE self, VALUE rb_namespace)
+{
+    const gchar *version;
+    version = gi_repository_get_version(SELF(self), RVAL2CSTR(rb_namespace));
+    return CSTR2RVAL(version);
+}
+
+void
+rbgi_repository_init(VALUE rb_mGLib)
+{
+    RG_TARGET_NAMESPACE = G_DEF_CLASS(GI_TYPE_REPOSITORY, "Repository", rb_mGLib);
+
+#if GLIB_CHECK_VERSION(2, 86, 0)
+    RG_DEF_SMETHOD(default, 0);
+#endif
+    RG_DEF_METHOD(prepend_search_path, 1);
+    RG_DEF_METHOD(search_path, 0);
+    RG_DEF_METHOD(require, -1);
+    RG_DEF_METHOD(get_dependencies, 1);
+    RG_DEF_METHOD(loaded_namespaces, 0);
+    RG_DEF_METHOD(get_n_infos, 1);
+    RG_DEF_METHOD(get_info, 2);
+    RG_DEF_METHOD(find, -1);
+    RG_DEF_METHOD(get_version, 1);
+
+    G_DEF_CLASS(GI_TYPE_REPOSITORY_LOAD_FLAGS, "RepositoryLoadFlags", rb_mGLib);
+    G_DEF_ERROR(GI_REPOSITORY_ERROR,
+                "RepositoryError",
+                rb_mGLib,
+                rb_eLoadError,
+                GI_TYPE_REPOSITORY_ERROR);
+}
+#endif

--- a/glib2/ext/glib2/rbglib.c
+++ b/glib2/ext/glib2/rbglib.c
@@ -1,6 +1,6 @@
 /* -*- c-file-style: "ruby"; indent-tabs-mode: nil -*- */
 /*
- *  Copyright (C) 2011-2025  Ruby-GNOME Project Team
+ *  Copyright (C) 2011-2026  Ruby-GNOME Project Team
  *  Copyright (C) 2002,2003  Masahiro Sakai
  *
  *  This library is free software; you can redistribute it and/or
@@ -22,6 +22,9 @@
 #include <locale.h>
 #include "rbgprivate.h"
 #include "rbglib.h"
+#ifdef HAVE_GIREPOSITORY
+#  include "rbgi-private.h"
+#endif
 
 #define RG_TARGET_NAMESPACE rbg_mGLib()
 
@@ -1294,4 +1297,9 @@ union       GDoubleIEEE754;
     Init_glib_time_zone();
     Init_glib_bytes();
     Init_glib_option();
+
+#ifdef HAVE_GIREPOSITORY
+    rbgi_repository_init(rbg_mGLib());
+    rbgi_base_info_init(rbg_mGLib());
+#endif
 }

--- a/glib2/ext/glib2/rbgobject.c
+++ b/glib2/ext/glib2/rbgobject.c
@@ -1,6 +1,6 @@
 /* -*- c-file-style: "ruby"; indent-tabs-mode: nil -*- */
 /*
- *  Copyright (C) 2003-2022  Ruby-GNOME Project Team
+ *  Copyright (C) 2003-2026  Ruby-GNOME Project Team
  *  Copyright (C) 2002,2003  Masahiro Sakai
  *  Copyright (C) 1998-2000  Yukihiro Matsumoto,
  *                           Daisuke Kanda,
@@ -24,6 +24,10 @@
 
 #include "rbgprivate.h"
 #include <ctype.h>
+
+#ifdef HAVE_GIREPOSITORY
+#  include "rbgi-private.h"
+#endif
 
 static ID id_relatives;
 static ID id_delete;
@@ -96,6 +100,11 @@ rbgobj_instance_from_ruby_object(VALUE obj)
     case G_TYPE_PARAM:
         return rbgobj_get_param_spec(obj);
     default:
+#ifdef HAVE_GIREPOSITORY
+      if (fundamental_type == GI_TYPE_BASE_INFO) {
+          return rbgi_base_info_from_ruby(obj);
+      }
+#endif
       {
         gpointer instance;
         if (!rbgobj_convert_robj2instance(fundamental_type, obj, &instance)) {

--- a/glib2/lib/glib-mkenums.rb
+++ b/glib2/lib/glib-mkenums.rb
@@ -3,9 +3,9 @@
 #
 # C language enum description generation library like as glib-mkenums tool.
 #
-# Copyright(C) 2006-2015 Ruby-GNOME2 Project.
+# Copyright (C) 2006-2026 Ruby-GNOME Project Team
 #
-# This program is licenced under the same license of Ruby-GNOME2.
+# This program is licensed under the same license of Ruby-GNOME.
 #
 
 module GLib
@@ -92,7 +92,13 @@ GType #{@enum_name}_get_type (void);
 
     private
     def to_snail_case(name)
-      prefix_processed_name = name.sub(/^[A-Z]/) do |prefix|
+      id_prefix = @options[:id_prefix]
+      if id_prefix
+        id_prefix_pattern = /\A#{Regexp.escape(id_prefix)}/
+      else
+        id_prefix_pattern = /\A[A-Z]/
+      end
+      prefix_processed_name = name.sub(id_prefix_pattern) do |prefix|
         prefix.downcase
       end
       snail_cased_name = prefix_processed_name.gsub(/[A-Z]+/) do |upper_case|
@@ -118,7 +124,7 @@ GType #{@enum_name}_get_type (void);
                 # GLIB_DEPRECATED_TYPE_IN_2_38_FOR(GTestSubprocessFlags)
                 (?:\s+[\w()\s]+)?
                 ;/mx) do |force_flags, constants, name|
-        enum_options = {}
+        enum_options = {id_prefix: options[:id_prefix]}
         enum_options[:force_flags] = !force_flags.nil?
         force_flags_patterns = [(options[:force_flags] || [])].flatten
         if force_flags_patterns.any? {|pattern| pattern === name}

--- a/glib2/lib/glib2.rb
+++ b/glib2/lib/glib2.rb
@@ -1,4 +1,4 @@
-# Copyright (C) 2005-2025  Ruby-GNOME Project Team
+# Copyright (C) 2005-2026  Ruby-GNOME Project Team
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -344,6 +344,10 @@ require "glib2/time-zone"
 require "glib2/value"
 require "glib2/variant"
 require "glib2/variant-type"
+
+if GLib.const_defined?(:Repository)
+  require_relative "glib2/repository"
+end
 
 =begin
 Don't we need this?

--- a/glib2/lib/glib2/repository.rb
+++ b/glib2/lib/glib2/repository.rb
@@ -1,0 +1,47 @@
+# Copyright (C) 2012-2026  Ruby-GNOME Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module GLib
+  class Repository
+    class << self
+      if Repository.respond_to?(:default)
+        alias_method :default_raw, :default
+        def default
+          @@default ||= default_raw
+        end
+      else
+        def default
+          @@default ||= new
+        end
+      end
+    end
+
+    include Enumerable
+
+    def each(*namespaces)
+       return to_enum(__method__, *namespaces) unless block_given?
+
+      if namespaces.empty?
+        namespaces = loaded_namespaces
+      end
+      namespaces.each do |namespace|
+        get_n_infos(namespace).times do |i|
+          yield(get_info(namespace, i))
+        end
+      end
+    end
+  end
+end

--- a/glib2/test/test-base-info.rb
+++ b/glib2/test/test-base-info.rb
@@ -1,0 +1,44 @@
+# Copyright (C) 2012-2026  Ruby-GNOME Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+class TestBaseInfo < Test::Unit::TestCase
+  include GLibTestUtils
+
+  def setup
+    unless GLib.const_defined?(:Repository)
+      omit("Need RUBY_GNOME_GLIB2_GIREPOSITORY_ENABLE=yes on build")
+    end
+    @repository = GLib::Repository.default
+    @repository.require("GObject")
+    @info = @repository.find("GObject", "Object")
+  end
+
+  def test_name
+    assert_equal("Object", @info.name)
+  end
+
+  def test_namespace
+    assert_equal("GObject", @info.namespace)
+  end
+
+  def test_container
+    assert_nil(@info.container)
+  end
+
+  def test_enumerable
+    assert_equal([], @info.to_a)
+  end
+end

--- a/glib2/test/test-repository.rb
+++ b/glib2/test/test-repository.rb
@@ -1,0 +1,73 @@
+# Copyright (C) 2012-2026  Ruby-GNOME Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+class TestRepository < Test::Unit::TestCase
+  include GLibTestUtils
+
+  def setup
+    unless GLib.const_defined?(:Repository)
+      omit("Need RUBY_GNOME_GLIB2_GIREPOSITORY_ENABLE=yes on build")
+    end
+    @repository = GLib::Repository.default
+    @repository.require("GObject")
+    @repository.require("Gio")
+  end
+
+  def test_search_path
+    repository = GLib::Repository.new
+    path = repository.search_path
+    repository.prepend_search_path(__dir__)
+    assert_equal([__dir__] + path,
+                 repository.search_path)
+  end
+
+  def test_get_n_infos
+    assert_kind_of(Integer, @repository.get_n_infos("GObject"))
+  end
+
+  def test_get_info
+    assert_kind_of(GLib::BaseInfo,
+                   @repository.get_info("GObject", 0))
+  end
+
+  def test_get_dependencies
+    assert_equal(["GLib-2.0"].sort,
+                 @repository.get_dependencies("GObject").sort)
+  end
+
+  def test_loaded_namespaces
+    assert_equal(["GLib", "GObject", "Gio", "GModule"].sort,
+                 @repository.loaded_namespaces.sort - ["GioUnix"])
+  end
+
+  def test_enumerable
+    namespaces = @repository.collect do |info|
+      info.namespace
+    end
+    assert_equal(["GLib", "GObject", "Gio", "GModule"].sort,
+                 namespaces.uniq.sort - ["GioUnix"])
+  end
+
+  def test_find_by_gtype
+    info = @repository.find(GLib::Object.gtype)
+    assert_equal("Object", info.name)
+  end
+
+  def test_find_by_name
+    info = @repository.find("GObject", "Object")
+    assert_equal("Object", info.name)
+  end
+end

--- a/helper.rb
+++ b/helper.rb
@@ -78,8 +78,12 @@ module Helper
   ]
 
   def all_packages
-    ALL_PACKAGES.reject do |package|
-      ENV["RUBY_GNOME_#{package.upcase.gsub("-", "_")}_ENABLE"] == "no"
+    if ENV["RUBY_GNOME_GLIB2_GIREPOSITORY_ENABLE"] == "yes"
+      ["glib2"]
+    else
+      ALL_PACKAGES.reject do |package|
+        ENV["RUBY_GNOME_#{package.upcase.gsub("-", "_")}_ENABLE"] == "no"
+      end
     end
   end
 


### PR DESCRIPTION
This is a minimum implementation. We need to migrate more files from gobject-introspection/.

It's built only with `RUBY_GNOME_GLIB2_GIREPOSITORY_ENABLE=yes` because we can't mix `libgirepository-1.0.so` and `girepository-2.0.so`.