### PR TITLE
glib2: add `GLib::ArgInfo`

### DIFF
--- a/glib2/ext/glib2/rbgi-arg-info.c
+++ b/glib2/ext/glib2/rbgi-arg-info.c
@@ -1,0 +1,226 @@
+/* -*- c-file-style: "ruby"; indent-tabs-mode: nil -*- */
+/*
+ *  Copyright (C) 2012-2026  Ruby-GNOME Project Team
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ *  MA  02110-1301  USA
+ */
+
+#ifdef HAVE_GIREPOSITORY
+#include "rbgi-private.h"
+
+#define RG_TARGET_NAMESPACE rb_cGIArgInfo
+#define SELF(self) (RVAL2GI_ARG_INFO(self))
+
+gboolean
+rbgi_arg_info_is_input_buffer(GIArgInfo *info)
+{
+    if (gi_arg_info_get_direction(info) != GI_DIRECTION_IN) {
+        return FALSE;
+    }
+
+    /* Heuristic */
+    const gchar *name = gi_base_info_get_name(GI_BASE_INFO(info));
+    if (strcmp(name, "buffer") != 0) {
+        return FALSE;
+    }
+
+    GITypeInfo type_info;
+    gi_arg_info_load_type_info(info, &type_info);
+    if (gi_type_info_get_tag(&type_info) != GI_TYPE_TAG_ARRAY) {
+        gi_base_info_clear(&type_info);
+        return FALSE;
+    }
+
+    GIArrayType array_type = gi_type_info_get_array_type(&type_info);
+    if (array_type != GI_ARRAY_TYPE_C) {
+        gi_base_info_clear(&type_info);
+        return FALSE;
+    }
+
+    unsigned int length_index;
+    if (!gi_type_info_get_array_length_index(&type_info, &length_index)) {
+        gi_base_info_clear(&type_info);
+        return FALSE;
+    }
+
+    GITypeInfo *element_type_info = gi_type_info_get_param_type(&type_info, 0);
+    GITypeTag element_type_tag = gi_type_info_get_tag(element_type_info);
+    gi_base_info_unref(element_type_info);
+    gi_base_info_clear(&type_info);
+    return element_type_tag == GI_TYPE_TAG_UINT8;
+}
+
+gboolean
+rbgi_arg_info_is_output_buffer(GIArgInfo *info)
+{
+    if (gi_arg_info_get_direction(info) != GI_DIRECTION_OUT) {
+        return FALSE;
+    }
+
+    if (!gi_arg_info_is_caller_allocates(info)) {
+        return FALSE;
+    }
+
+    GITypeInfo type_info;
+    gi_arg_info_load_type_info(info, &type_info);
+    if (gi_type_info_get_tag(&type_info) != GI_TYPE_TAG_ARRAY) {
+        gi_base_info_clear(&type_info);
+        return FALSE;
+    }
+
+    GITypeInfo *element_type_info = gi_type_info_get_param_type(&type_info, 0);
+    GITypeTag element_type_tag = gi_type_info_get_tag(element_type_info);
+    gi_base_info_unref(element_type_info);
+    gi_base_info_clear(&type_info);
+    return element_type_tag == GI_TYPE_TAG_UINT8;
+}
+
+static VALUE
+rg_direction(VALUE self)
+{
+    GIArgInfo *info;
+
+    info = SELF(self);
+    return GI_DIRECTION2RVAL(gi_arg_info_get_direction(info));
+}
+
+static VALUE
+rg_caller_allocates_p(VALUE self)
+{
+    GIArgInfo *info;
+
+    info = SELF(self);
+    return CBOOL2RVAL(gi_arg_info_is_caller_allocates(info));
+}
+
+static VALUE
+rg_return_value_p(VALUE self)
+{
+    GIArgInfo *info;
+
+    info = SELF(self);
+    return CBOOL2RVAL(gi_arg_info_is_return_value(info));
+}
+
+static VALUE
+rg_optional_p(VALUE self)
+{
+    GIArgInfo *info;
+
+    info = SELF(self);
+    return CBOOL2RVAL(gi_arg_info_is_optional(info));
+}
+
+static VALUE
+rg_may_be_null_p(VALUE self)
+{
+    GIArgInfo *info;
+
+    info = SELF(self);
+    return CBOOL2RVAL(gi_arg_info_may_be_null(info));
+}
+
+static VALUE
+rg_ownership_transfer(VALUE self)
+{
+    GIArgInfo *info;
+
+    info = SELF(self);
+    return GI_TRANSFER2RVAL(gi_arg_info_get_ownership_transfer(info));
+}
+
+static VALUE
+rg_scope(VALUE self)
+{
+    GIArgInfo *info;
+
+    info = SELF(self);
+    return GI_SCOPE_TYPE2RVAL(gi_arg_info_get_scope(info));
+}
+
+static VALUE
+rg_closure_index(VALUE self)
+{
+    GIArgInfo *info = SELF(self);
+    unsigned int closure_index;
+    if (gi_arg_info_get_closure_index(info, &closure_index)) {
+        return UINT2NUM(closure_index);
+    } else {
+        return Qnil;
+    }
+}
+
+static VALUE
+rg_destroy_index(VALUE self)
+{
+    GIArgInfo *info = SELF(self);
+    unsigned int destroy_index;
+    if (gi_arg_info_get_destroy_index(info, &destroy_index)) {
+        return UINT2NUM(destroy_index);
+    } else {
+        return Qnil;
+    }
+}
+
+static VALUE
+rg_type(VALUE self)
+{
+    GIArgInfo *info;
+
+    info = SELF(self);
+    return GOBJ2RVAL_UNREF(gi_arg_info_get_type_info(info));
+}
+
+static VALUE
+rg_input_buffer_p(VALUE self)
+{
+    GIArgInfo *info = SELF(self);
+    return CBOOL2RVAL(rbgi_arg_info_is_input_buffer(info));
+}
+
+static VALUE
+rg_output_buffer_p(VALUE self)
+{
+    GIArgInfo *info = SELF(self);
+    return CBOOL2RVAL(rbgi_arg_info_is_output_buffer(info));
+}
+
+void
+rbgi_arg_info_init(VALUE rb_mGLib)
+{
+    VALUE RG_TARGET_NAMESPACE;
+
+    RG_TARGET_NAMESPACE = G_DEF_CLASS(GI_TYPE_ARG_INFO, "ArgInfo", rb_mGLib);
+
+    RG_DEF_METHOD(direction, 0);
+    RG_DEF_METHOD_P(caller_allocates, 0);
+    RG_DEF_METHOD_P(return_value, 0);
+    RG_DEF_METHOD_P(optional, 0);
+    RG_DEF_METHOD_P(may_be_null, 0);
+    RG_DEF_METHOD(ownership_transfer, 0);
+    RG_DEF_METHOD(scope, 0);
+    RG_DEF_METHOD(closure_index, 0);
+    RG_DEF_METHOD(destroy_index, 0);
+    RG_DEF_METHOD(type, 0);
+
+    RG_DEF_METHOD_P(input_buffer, 0);
+    RG_DEF_METHOD_P(output_buffer, 0);
+
+    G_DEF_CLASS(GI_TYPE_DIRECTION, "Direction", rb_mGLib);
+    G_DEF_CLASS(GI_TYPE_SCOPE_TYPE, "ScopeType", rb_mGLib);
+    G_DEF_CLASS(GI_TYPE_TRANSFER, "Transfer", rb_mGLib);
+}
+#endif

--- a/glib2/ext/glib2/rbgi-base-info.c
+++ b/glib2/ext/glib2/rbgi-base-info.c
@@ -28,7 +28,7 @@ static VALUE RG_TARGET_NAMESPACE;
 static void
 rbgi_base_info_free(void *data)
 {
-    GIBaseInfoStack *info = data;
+    GIBaseInfo *info = data;
     gi_base_info_unref(info);
 }
 
@@ -55,33 +55,8 @@ rbgi_base_info_alloc_func(VALUE klass)
                                  NULL);
 }
 
-VALUE
-rbgi_base_info_to_ruby(GIBaseInfo *info)
-{
-    if (!info) {
-        return Qnil;
-    }
-
-    gi_base_info_ref(info);
-    return TypedData_Wrap_Struct(RG_TARGET_NAMESPACE,
-                                 &rbgi_base_info_type,
-                                 info);
-}
-
-VALUE
-rbgi_base_info_to_ruby_take(GIBaseInfo *info)
-{
-    if (!info) {
-        return Qnil;
-    }
-
-    return TypedData_Wrap_Struct(RG_TARGET_NAMESPACE,
-                                 &rbgi_base_info_type,
-                                 info);
-}
-
-GIBaseInfo *
-rbgi_base_info_from_ruby(VALUE rb_info)
+static gpointer
+rbgi_base_info_robj2instance(VALUE rb_info, gpointer user_data)
 {
     GIBaseInfo *info;
     TypedData_Get_Struct(rb_info,
@@ -89,6 +64,48 @@ rbgi_base_info_from_ruby(VALUE rb_info)
                          &rbgi_base_info_type,
                          info);
     return info;
+}
+
+static VALUE
+rbgi_base_info_instance2robj(gpointer instance, gpointer user_data)
+{
+    GIBaseInfo *info = instance;
+    if (!info) {
+        return Qnil;
+    }
+
+    VALUE klass = RG_TARGET_NAMESPACE;
+    GType type = G_TYPE_FROM_INSTANCE(info);
+    if (type == GI_TYPE_ARG_INFO) {
+        ID id_ArgInfo;
+        RUBY_CONST_ID(id_ArgInfo, "ArgInfo");
+        klass = rb_const_get(rbg_mGLib(), id_ArgInfo);
+    } else if (type == GI_TYPE_CALLABLE_INFO) {
+        ID id_CallableInfo;
+        RUBY_CONST_ID(id_CallableInfo, "CallableInfo");
+        klass = rb_const_get(rbg_mGLib(), id_CallableInfo);
+    } else if (type == GI_TYPE_FUNCTION_INFO) {
+        ID id_FunctionInfo;
+        RUBY_CONST_ID(id_FunctionInfo, "FunctionInfo");
+        klass = rb_const_get(rbg_mGLib(), id_FunctionInfo);
+    } else if (type == GI_TYPE_TYPE_INFO) {
+        ID id_TypeInfo;
+        RUBY_CONST_ID(id_TypeInfo, "TypeInfo");
+        klass = rb_const_get(rbg_mGLib(), id_TypeInfo);
+    }
+
+    gi_base_info_ref(info);
+    return TypedData_Wrap_Struct(klass, &rbgi_base_info_type, info);
+}
+
+static void
+rbgi_base_info_unref(gpointer instance, gpointer user_data)
+{
+    GIBaseInfo *info = instance;
+    if (!info) {
+        return;
+    }
+    gi_base_info_unref(info);
 }
 
 static VALUE
@@ -112,10 +129,8 @@ rg_namespace(VALUE self)
 static VALUE
 rg_container(VALUE self)
 {
-    GIBaseInfo *info;
-
-    info = SELF(self);
-    return rbgi_base_info_to_ruby(gi_base_info_get_container(info));
+    GIBaseInfo *info = SELF(self);
+    return GOBJ2RVAL(gi_base_info_get_container(info));
 }
 
 static VALUE
@@ -152,6 +167,22 @@ rbgi_base_info_init(VALUE rb_mGLib)
 {
     RG_TARGET_NAMESPACE = G_DEF_CLASS(GI_TYPE_BASE_INFO, "BaseInfo", rb_mGLib);
     rb_define_alloc_func(RG_TARGET_NAMESPACE, rbgi_base_info_alloc_func);
+
+    RGConvertTable table = {
+      .type = GI_TYPE_BASE_INFO,
+      .klass = RG_TARGET_NAMESPACE,
+      .user_data = NULL,
+      .notify = NULL,
+      .get_superclass = NULL,
+      .type_init_hook = NULL,
+      .rvalue2gvalue = NULL,
+      .gvalue2rvalue = NULL,
+      .initialize = NULL,
+      .robj2instance = rbgi_base_info_robj2instance,
+      .instance2robj = rbgi_base_info_instance2robj,
+      .unref = rbgi_base_info_unref,
+    };
+    RG_DEF_CONVERSION(&table);
 
     rb_include_module(RG_TARGET_NAMESPACE, rb_mEnumerable);
 

--- a/glib2/ext/glib2/rbgi-callable-info.c
+++ b/glib2/ext/glib2/rbgi-callable-info.c
@@ -18,23 +18,37 @@
  *  MA  02110-1301  USA
  */
 
-#pragma once
+#ifdef HAVE_GIREPOSITORY
+#include "rbgi-private.h"
 
-#include "rbgprivate.h"
-#include "rbglib2conversions.h"
+#define RG_TARGET_NAMESPACE rb_cGICallableInfo
+#define SELF(self) RVAL2GI_CALLABLE_INFO(self)
 
-#include <girepository/girepository.h>
-#include <girepository/girffi.h>
+static VALUE
+rg_n_args(VALUE self)
+{
+    GICallableInfo *info = SELF(self);
+    return INT2NUM(gi_callable_info_get_n_args(info));
+}
 
-#include "gi-enum-types.h"
-#include "rbgi-conversions.h"
+static VALUE
+rg_get_arg(VALUE self, VALUE rb_n)
+{
+    GICallableInfo *info = SELF(self);
+    gint n = NUM2INT(rb_n);
+    return GOBJ2RVAL_UNREF(gi_callable_info_get_arg(info, n));
+}
 
-G_GNUC_INTERNAL void rbgi_arg_info_init(VALUE mGLib);
-G_GNUC_INTERNAL void rbgi_callable_info_init(VALUE mGLib);
-G_GNUC_INTERNAL void rbgi_base_info_init(VALUE mGLib);
-G_GNUC_INTERNAL void rbgi_repository_init(VALUE mGLib);
+void
+rbgi_callable_info_init(VALUE rb_mGLib)
+{
+    VALUE RG_TARGET_NAMESPACE;
 
-G_GNUC_INTERNAL gboolean
-rbgi_arg_info_is_input_buffer(GIArgInfo *info);
-G_GNUC_INTERNAL gboolean
-rbgi_arg_info_is_output_buffer(GIArgInfo *info);
+    RG_TARGET_NAMESPACE =
+        G_DEF_CLASS(GI_TYPE_CALLABLE_INFO, "CallableInfo", rb_mGLib);
+
+    /* TODO: More methods */
+    RG_DEF_METHOD(n_args, 0);
+    RG_DEF_METHOD(get_arg, 1);
+}
+#endif

--- a/glib2/ext/glib2/rbgi-conversions.h
+++ b/glib2/ext/glib2/rbgi-conversions.h
@@ -23,10 +23,10 @@
 #define RVAL2GI_REPOSITORY_LOAD_FLAGS(rb_flags) \
     (RVAL2GFLAGS(rb_flags, GI_TYPE_REPOSITORY_LOAD_FLAGS))
 
-GIBaseInfo *rbgi_base_info_from_ruby(VALUE rb_info);
-VALUE rbgi_base_info_to_ruby(GIBaseInfo *info);
-VALUE rbgi_base_info_to_ruby_take(GIBaseInfo *info);
+#define RVAL2GI_ARG_INFO(rb_info)      GI_ARG_INFO(RVAL2GOBJ(rb_info))
+#define RVAL2GI_BASE_INFO(rb_info)     GI_BASE_INFO(RVAL2GOBJ(rb_info))
+#define RVAL2GI_CALLABLE_INFO(rb_info) GI_CALLABLE_INFO(RVAL2GOBJ(rb_info))
 
-#define RVAL2GI_BASE_INFO(rb_info)   rbgi_base_info_from_ruby(rb_info)
-#define GI_BASE_INFO2RVAL(info)      rbgi_base_info_to_ruby(info)
-#define GI_BASE_INFO2RVAL_TAKE(info) rbgi_base_info_to_ruby_take(info)
+#define GI_DIRECTION2RVAL(direction) (GENUM2RVAL(direction, GI_TYPE_DIRECTION))
+#define GI_SCOPE_TYPE2RVAL(scope)    (GENUM2RVAL(scope, GI_TYPE_SCOPE_TYPE))
+#define GI_TRANSFER2RVAL(transfer)   (GENUM2RVAL(transfer, GI_TYPE_TRANSFER))

--- a/glib2/ext/glib2/rbgi-repository.c
+++ b/glib2/ext/glib2/rbgi-repository.c
@@ -192,7 +192,7 @@ rg_get_info(VALUE self, VALUE rb_namespace, VALUE rb_n)
     namespace_ = RVAL2CSTR(rb_namespace);
     n = NUM2INT(rb_n);
     info = gi_repository_get_info(repository, namespace_, n);
-    return GI_BASE_INFO2RVAL_TAKE(info);
+    return GOBJ2RVAL_UNREF(info);
 }
 
 
@@ -216,7 +216,6 @@ rg_get_info(VALUE self, VALUE rb_namespace, VALUE rb_n)
  *
  * @return [GLib::BaseInfo] The metadata entry.
  */
-
 static VALUE
 rg_find(int argc, VALUE *argv, VALUE self)
 {
@@ -238,7 +237,7 @@ rg_find(int argc, VALUE *argv, VALUE self)
         info = gi_repository_find_by_name(SELF(self), namespace_, name);
     }
 
-    return GI_BASE_INFO2RVAL(info);
+    return GOBJ2RVAL_UNREF(info);
 }
 
 static VALUE

--- a/glib2/ext/glib2/rbglib.c
+++ b/glib2/ext/glib2/rbglib.c
@@ -1299,7 +1299,17 @@ union       GDoubleIEEE754;
     Init_glib_option();
 
 #ifdef HAVE_GIREPOSITORY
-    rbgi_repository_init(rbg_mGLib());
     rbgi_base_info_init(rbg_mGLib());
+
+    rbgi_arg_info_init(rbg_mGLib());
+    rbgi_callable_info_init(rbg_mGLib());
+    /* TODO */
+    /* rbgi_function_info_init(rbg_mGLib()); */
+    G_DEF_CLASS(GI_TYPE_FUNCTION_INFO, "FunctionInfo", rbg_mGLib());
+    /* TODO */
+    /* rbgi_type_info_init(rbg_mGLib()); */
+    G_DEF_CLASS(GI_TYPE_TYPE_INFO, "TypeInfo", rbg_mGLib());
+
+    rbgi_repository_init(rbg_mGLib());
 #endif
 }

--- a/glib2/ext/glib2/rbgobject.c
+++ b/glib2/ext/glib2/rbgobject.c
@@ -100,11 +100,6 @@ rbgobj_instance_from_ruby_object(VALUE obj)
     case G_TYPE_PARAM:
         return rbgobj_get_param_spec(obj);
     default:
-#ifdef HAVE_GIREPOSITORY
-      if (fundamental_type == GI_TYPE_BASE_INFO) {
-          return rbgi_base_info_from_ruby(obj);
-      }
-#endif
       {
         gpointer instance;
         if (!rbgobj_convert_robj2instance(fundamental_type, obj, &instance)) {

--- a/glib2/test/glib-test-utils.rb
+++ b/glib2/test/glib-test-utils.rb
@@ -40,6 +40,12 @@ module GLibTestUtils
     omit("Not for SCL environment") if ENV["SCL"]
   end
 
+  def only_girepository
+    unless GLib.const_defined?(:Repository)
+      omit("Need RUBY_GNOME_GLIB2_GIREPOSITORY_ENABLE=yes on build")
+    end
+  end
+
   def normalize_path(path)
     return path unless File::ALT_SEPARATOR
     path.gsub(File::ALT_SEPARATOR, File::SEPARATOR)

--- a/glib2/test/test-arg-info.rb
+++ b/glib2/test/test-arg-info.rb
@@ -1,0 +1,79 @@
+# Copyright (C) 2012-2026  Ruby-GNOME Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+class TestArgInfo < Test::Unit::TestCase
+  include GLibTestUtils
+
+  def setup
+    only_girepository
+    @repository = GLib::Repository.default
+    @repository.require("GObject")
+    @callable_info = @repository.find("GObject", "signal_name")
+    @info = @callable_info.get_arg(0)
+  end
+
+  def test_direction
+    assert_equal(GLib::Direction::IN,
+                 @info.direction)
+  end
+
+  def test_caller_allocate?
+    assert do
+      not @info.caller_allocates?
+    end
+  end
+
+  def test_return_value?
+    assert do
+      not @info.return_value?
+    end
+  end
+
+  def test_optional?
+    assert do
+      not @info.optional?
+    end
+  end
+
+  def test_may_be_null?
+    assert do
+      not @info.may_be_null?
+    end
+  end
+
+  def test_ownership_transfer
+    assert_equal(GLib::Transfer::NOTHING,
+                 @info.ownership_transfer)
+  end
+
+  def test_scope
+    assert_equal(GLib::ScopeType::INVALID,
+                 @info.scope)
+  end
+
+  def test_closure_index
+    assert_nil(@info.closure_index)
+  end
+
+  def test_destroy_index
+    assert_nil(@info.destroy_index)
+  end
+
+  def test_type
+    assert_kind_of(GLib::TypeInfo,
+                   @info.type)
+  end
+end

--- a/glib2/test/test-base-info.rb
+++ b/glib2/test/test-base-info.rb
@@ -18,9 +18,7 @@ class TestBaseInfo < Test::Unit::TestCase
   include GLibTestUtils
 
   def setup
-    unless GLib.const_defined?(:Repository)
-      omit("Need RUBY_GNOME_GLIB2_GIREPOSITORY_ENABLE=yes on build")
-    end
+    only_girepository
     @repository = GLib::Repository.default
     @repository.require("GObject")
     @info = @repository.find("GObject", "Object")

--- a/glib2/test/test-repository.rb
+++ b/glib2/test/test-repository.rb
@@ -18,9 +18,7 @@ class TestRepository < Test::Unit::TestCase
   include GLibTestUtils
 
   def setup
-    unless GLib.const_defined?(:Repository)
-      omit("Need RUBY_GNOME_GLIB2_GIREPOSITORY_ENABLE=yes on build")
-    end
+    only_girepository
     @repository = GLib::Repository.default
     @repository.require("GObject")
     @repository.require("Gio")


### PR DESCRIPTION
Minimum `GLib::CallableInfo`/`GLib::FunctionInfo`/`GLib::TypeInfo` are also added for testing. We'll implement them later.