### PR TITLE
glib2: ruby/thread.h is always available

### DIFF
--- a/glib2/ext/glib2/extconf.rb
+++ b/glib2/ext/glib2/extconf.rb
@@ -60,16 +60,10 @@ have_func("rb_check_array_type", ruby_header)
 have_func("rb_check_hash_type", ruby_header)
 have_func("rb_exec_recursive", ruby_header)
 have_func("rb_errinfo", ruby_header)
-have_func("rb_thread_call_without_gvl", ruby_header)
-have_func("ruby_native_thread_p", ruby_header)
-have_func("rb_thread_call_with_gvl", ruby_header)
 have_func("rb_gc_register_mark_object", ruby_header)
 have_func("rb_exc_new_str", ruby_header)
 # For Ruby 2.1. TODO: Remove this when we drop Ruby 2.1 support.
 have_func("rb_enc_str_new_static", ruby_header)
-
-have_var("curr_thread", [ruby_header, "node.h"])
-have_var("rb_curr_thread", [ruby_header, "node.h"])
 
 create_pkg_config_file("Ruby/GLib2", package_id)
 

--- a/glib2/ext/glib2/rbglib_maincontext.c
+++ b/glib2/ext/glib2/rbglib_maincontext.c
@@ -1,6 +1,6 @@
 /* -*- c-file-style: "ruby"; indent-tabs-mode: nil -*- */
 /*
- *  Copyright (C) 2011-2025  Ruby-GNOME Project Team
+ *  Copyright (C) 2011-2026  Ruby-GNOME Project Team
  *  Copyright (C) 2005  Masao Mutoh
  *
  *  This library is free software; you can redistribute it and/or
@@ -20,10 +20,6 @@
  */
 
 #include "rbgprivate.h"
-
-#ifdef HAVE_RUBY_THREAD_H
-#  include <ruby/thread.h>
-#endif
 
 GPrivate rg_polling_key = G_PRIVATE_INIT(NULL);
 
@@ -59,7 +55,6 @@ rg_poll_in_blocking_raw(PollInfo *info)
     info->result = default_poll_func(info->ufds, info->nfsd, info->timeout);
 }
 
-#ifdef HAVE_RB_THREAD_CALL_WITHOUT_GVL
 static void *
 rg_poll_in_blocking(void *data)
 {
@@ -67,15 +62,6 @@ rg_poll_in_blocking(void *data)
     rg_poll_in_blocking_raw(info);
     return NULL;
 }
-#else
-static VALUE
-rg_poll_in_blocking(void *data)
-{
-    PollInfo *info = data;
-    rg_poll_in_blocking_raw(info);
-    return Qnil;
-}
-#endif
 
 static gint
 rg_poll(GPollFD *ufds, guint nfsd, gint timeout)
@@ -89,13 +75,8 @@ rg_poll(GPollFD *ufds, guint nfsd, gint timeout)
 
     g_private_set(&rg_polling_key, GINT_TO_POINTER(TRUE));
     if (g_thread_self() == main_thread) {
-#ifdef HAVE_RB_THREAD_CALL_WITHOUT_GVL
         rb_thread_call_without_gvl(rg_poll_in_blocking, &info,
                                    RUBY_UBF_IO, NULL);
-#else
-        rb_thread_blocking_region(rg_poll_in_blocking, &info,
-                                  RUBY_UBF_IO, NULL);
-#endif
     } else {
         rg_poll_in_blocking_raw(&info);
     }

--- a/glib2/ext/glib2/rbgobject.h
+++ b/glib2/ext/glib2/rbgobject.h
@@ -1,6 +1,6 @@
 /* -*- c-file-style: "ruby"; indent-tabs-mode: nil -*- */
 /*
- *  Copyright (C) 2003-2025  Ruby-GNOME Project Team
+ *  Copyright (C) 2003-2026  Ruby-GNOME Project Team
  *  Copyright (C) 2002,2003  Masahiro Sakai
  *
  *  This library is free software; you can redistribute it and/or
@@ -23,6 +23,7 @@
 
 #include <glib-object.h>
 #include <ruby.h>
+#include <ruby/thread.h>
 #include "rbglib.h"
 #include "rbgutil.h"
 

--- a/glib2/ext/glib2/rbgutil_callback.c
+++ b/glib2/ext/glib2/rbgutil_callback.c
@@ -1,6 +1,6 @@
 /* -*- c-file-style: "ruby"; indent-tabs-mode: nil -*- */
 /*
- *  Copyright (C) 2007-2022  Ruby-GNOME Project Team
+ *  Copyright (C) 2007-2026  Ruby-GNOME Project Team
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -33,10 +33,6 @@
 #include <fcntl.h>
 #include <errno.h>
 
-#ifndef HAVE_RUBY_NATIVE_THREAD_P
-#  define ruby_native_thread_p() is_ruby_native_thread()
-#endif
-
 static VALUE rbgutil_eGLibCallbackNotInitializedError;
 static ID id_exit_application;
 
@@ -60,8 +56,6 @@ rbgutil_on_callback_error(VALUE error)
 }
 
 /**********************************************************************/
-
-#ifdef HAVE_NATIVETHREAD
 
 typedef struct _CallbackRequest {
     VALUE (*function)(VALUE);
@@ -181,42 +175,31 @@ invoke_callback_in_ruby_thread(VALUE (*func)(VALUE), VALUE arg)
     return request.result;
 }
 
-#ifdef HAVE_RB_THREAD_CALL_WITH_GVL
-extern void *rb_thread_call_with_gvl(void *(*func)(void *), void *data1);
-
 static void *
 invoke_callback_with_gvl(void *arg)
 {
     CallbackRequest *req = (CallbackRequest*)arg;
     return (void *)rbgutil_protect(req->function, req->argument);
 }
-#endif
-
-#endif
 
 /**********************************************************************/
 
 VALUE
 rbgutil_invoke_callback(VALUE (*func)(VALUE), VALUE arg)
 {
-#ifdef HAVE_NATIVETHREAD
     if (ruby_native_thread_p()) {
         if (!GPOINTER_TO_INT(g_private_get(&rg_polling_key))) {
             return rbgutil_protect(func, arg);
         }
-#  ifdef HAVE_RB_THREAD_CALL_WITH_GVL
         {
             CallbackRequest req;
             req.function = func;
             req.argument = arg;
             return (VALUE)rb_thread_call_with_gvl(invoke_callback_with_gvl, &req);
         }
-#  endif
     } else {
         return invoke_callback_in_ruby_thread(func, arg);
     }
-#endif
-    return rbgutil_protect(func, arg);
 }
 
 /**********************************************************************/
@@ -224,7 +207,6 @@ rbgutil_invoke_callback(VALUE (*func)(VALUE), VALUE arg)
 void
 rbgutil_start_callback_dispatch_thread(void)
 {
-#ifdef HAVE_NATIVETHREAD
     VALUE callback_dispatch_thread;
 
     g_mutex_lock(&callback_dispatch_thread_mutex);
@@ -238,13 +220,11 @@ rbgutil_start_callback_dispatch_thread(void)
                     callback_dispatch_thread);
     }
     g_mutex_unlock(&callback_dispatch_thread_mutex);
-#endif
 }
 
 void
 rbgutil_stop_callback_dispatch_thread(void)
 {
-#ifdef HAVE_NATIVETHREAD
     VALUE callback_dispatch_thread;
 
     g_mutex_lock(&callback_dispatch_thread_mutex);
@@ -254,7 +234,6 @@ rbgutil_stop_callback_dispatch_thread(void)
         rb_ivar_set(rbg_mGLib(), id_callback_dispatch_thread, Qnil);
     }
     g_mutex_unlock(&callback_dispatch_thread_mutex);
-#endif
 }
 
 void
@@ -265,11 +244,9 @@ Init_gutil_callback(void)
         rb_define_class_under(rbg_mGLib(), "CallbackNotInitializedError",
                               rb_eRuntimeError);
 
-#ifdef HAVE_NATIVETHREAD
     id_callback_dispatch_thread = rb_intern("callback_dispatch_thread");
     rb_ivar_set(rbg_mGLib(), id_callback_dispatch_thread, Qnil);
 
     callback_request_queue = g_async_queue_new();
     g_mutex_init(&callback_dispatch_thread_mutex);
-#endif
 }


### PR DESCRIPTION
We don't support old Ruby.