### PR TITLE
glib2: fix `GLib::InterfaceInfo` implementation

### DIFF
--- a/glib2/ext/glib2/rbgi-base-info.c
+++ b/glib2/ext/glib2/rbgi-base-info.c
@@ -84,6 +84,10 @@ rbgi_base_info_instance2robj(gpointer instance, gpointer user_data)
         ID id_CallableInfo;
         RUBY_CONST_ID(id_CallableInfo, "CallableInfo");
         klass = rb_const_get(rbg_mGLib(), id_CallableInfo);
+    } else if (type == GI_TYPE_CONSTANT_INFO) {
+        ID id_ConstantInfo;
+        RUBY_CONST_ID(id_ConstantInfo, "ConstantInfo");
+        klass = rb_const_get(rbg_mGLib(), id_ConstantInfo);
     } else if (type == GI_TYPE_FUNCTION_INFO) {
         ID id_FunctionInfo;
         RUBY_CONST_ID(id_FunctionInfo, "FunctionInfo");

--- a/glib2/ext/glib2/rbgi-interface-info.c
+++ b/glib2/ext/glib2/rbgi-interface-info.c
@@ -95,7 +95,7 @@ rg_get_signal(VALUE self, VALUE rb_n_or_name)
         const char *name = RVAL2CSTR(rb_n_or_name);
         signal_info = gi_interface_info_find_signal(info, name);
     }
-    return GOBJ2RVAL(signal_info);
+    return GOBJ2RVAL_UNREF(signal_info);
 }
 
 static VALUE
@@ -117,7 +117,7 @@ rg_get_vfunc(VALUE self, VALUE rb_n_or_name)
         const gchar *name = RVAL2CSTR(rb_n_or_name);
         vfunc_info = gi_interface_info_find_vfunc(info, name);
     }
-    return GOBJ2RVAL(vfunc_info);
+    return GOBJ2RVAL_UNREF(vfunc_info);
 }
 
 static VALUE
@@ -139,7 +139,7 @@ static VALUE
 rg_iface_struct(VALUE self)
 {
     GIInterfaceInfo *info = SELF(self);
-    return GOBJ2RVAL(gi_interface_info_get_iface_struct(info));
+    return GOBJ2RVAL_UNREF(gi_interface_info_get_iface_struct(info));
 }
 
 void

--- a/glib2/ext/glib2/rbglib.c
+++ b/glib2/ext/glib2/rbglib.c
@@ -1304,6 +1304,9 @@ union       GDoubleIEEE754;
     rbgi_arg_info_init(rbg_mGLib());
     rbgi_callable_info_init(rbg_mGLib());
     /* TODO */
+    /* rbgi_constant_info_init(rbg_mGLib()); */
+    G_DEF_CLASS(GI_TYPE_CONSTANT_INFO, "ConstantInfo", rbg_mGLib());
+    /* TODO */
     /* rbgi_function_info_init(rbg_mGLib()); */
     G_DEF_CLASS(GI_TYPE_FUNCTION_INFO, "FunctionInfo", rbg_mGLib());
     rbgi_interface_info_init(rbg_mGLib());

--- a/glib2/test/test-interface-info.rb
+++ b/glib2/test/test-interface-info.rb
@@ -37,7 +37,7 @@ class TestInterfaceInfo < Test::Unit::TestCase
     assert_equal(1, @info.n_properties)
   end
 
-  def test_propertiy
+  def test_property
     assert_kind_of(GLib::PropertyInfo,
                    @info.get_property(0))
   end
@@ -75,7 +75,9 @@ class TestInterfaceInfo < Test::Unit::TestCase
 
   def test_n_vfuncs
     info = @repository.find("Gio", "Volume")
-    assert_operator(0, :<, info.n_vfuncs)
+    assert do
+      info.n_vfuncs > 0
+    end
   end
 
   def test_get_vfunc_n
@@ -88,6 +90,21 @@ class TestInterfaceInfo < Test::Unit::TestCase
     info = @repository.find("Gio", "Volume")
     assert_kind_of(GLib::VFuncInfo,
                    info.get_vfunc("can_eject"))
+  end
+
+  def test_n_constants
+    omit("Find an interface info that has constants")
+    info = @repository.find("Gio", "XXX")
+    assert do
+      info.n_constants > 0
+    end
+  end
+
+  def test_get_constant
+    omit("Find an interface info that has constants")
+    info = @repository.find("Gio", "XXX")
+    assert_kind_of(GLib::ConstantInfo,
+                   info.get_constant(0))
   end
 
   def test_iface_struct


### PR DESCRIPTION
* Add missing constant tests (but omitted because of no suitable real interface info)
* Add missing unref
* Fix typos
* Fix styles