### PR TITLE
glib2 test: use WeakRef

### DIFF
--- a/glib2/test/glib-test-utils.rb
+++ b/glib2/test/glib-test-utils.rb
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2022  Ruby-GNOME Project Team
+# Copyright (C) 2015-2026  Ruby-GNOME Project Team
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -15,6 +15,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 require "pathname"
+require "weakref"
 
 require "test-unit"
 

--- a/glib2/test/test-bytes.rb
+++ b/glib2/test/test-bytes.rb
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2021  Ruby-GNOME Project Team
+# Copyright (C) 2017-2026  Ruby-GNOME Project Team
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -42,14 +42,17 @@ class TestGLibBytes < Test::Unit::TestCase
     def create_bytes(options={})
       data = "Hello"
       data.freeze if options[:freeze]
-      [data.object_id, GLib::Bytes.new(data)]
+      [WeakRef.new(data), GLib::Bytes.new(data)]
     end
 
     test "frozen" do
-      id, bytes = create_bytes(:freeze => true)
+      ref, bytes = create_bytes(:freeze => true)
       GC.start
+      assert do
+        ref.weakref_alive?
+      end
       assert_equal(bytes.to_s,
-                   ObjectSpace._id2ref(id))
+                   ref.to_s)
     end
   end
 


### PR DESCRIPTION
`ObjectSpace._id2ref` is removed.