### PR TITLE
Reproducible patch for causing SEGV by callback

### DIFF
--- a/glib2/test/fixture/Rakefile
+++ b/glib2/test/fixture/Rakefile
@@ -1,0 +1,13 @@
+TARGET = "callback-requester/callback_requester.#{RbConfig::CONFIG['DLEXT']}"
+
+task default: TARGET
+
+file TARGET => ["callback-requester/extconf.rb", "callback-requester/callback-requester.c"] do |t|
+  cd "callback-requester" do
+    ruby "extconf.rb"
+    sh "make"
+  end
+end
+
+file "requester/extconf.rb"
+file "callback-requester/testcallback-requester.c"

--- a/glib2/test/fixture/callback-requester/callback-requester.c
+++ b/glib2/test/fixture/callback-requester/callback-requester.c
@@ -1,0 +1,75 @@
+#include "rbgutil.h"
+
+typedef struct {
+    VALUE obj;
+} callback_requester;
+
+static VALUE
+touch_object(VALUE obj)
+{
+    rb_funcall(rb_cObject, rb_intern("p"), 1, obj);
+
+    return Qnil;
+}
+
+static void
+callback_requester_free(void *data)
+{
+    callback_requester *requester = (callback_requester *)data;
+
+    if (!requester) {
+        return;
+    }
+
+    rbgutil_invoke_callback_async(touch_object, requester->obj);
+    xfree(requester);
+}
+
+static const rb_data_type_t callback_requester_type = {
+    "CallbackRequester",
+    {
+        NULL, // Doesn't mark `obj` member for test purpose
+        callback_requester_free,
+    },
+    NULL,
+    NULL,
+    RUBY_TYPED_FREE_IMMEDIATELY,
+};
+
+static VALUE
+callback_requester_alloc(VALUE klass)
+{
+    callback_requester *requester;
+    VALUE self = TypedData_Make_Struct(klass,
+                                       callback_requester,
+                                       &callback_requester_type,
+                                       requester);
+    requester->obj = Qnil;
+
+    return self;
+}
+
+static VALUE
+callback_requester_initialize(VALUE self, VALUE obj)
+{
+    callback_requester *requester;
+
+    TypedData_Get_Struct(self,
+                         callback_requester,
+                         &callback_requester_type,
+                         requester);
+    requester->obj = obj;
+
+    return Qnil;
+}
+
+void
+Init_callback_requester(void)
+{
+    VALUE klass = rb_define_class("CallbackRequester", rb_cObject);
+
+    rb_define_alloc_func(klass, callback_requester_alloc);
+    rb_define_method(klass, "initialize", callback_requester_initialize, 1);
+
+    rbgutil_start_callback_dispatch_thread();
+}

--- a/glib2/test/fixture/callback-requester/extconf.rb
+++ b/glib2/test/fixture/callback-requester/extconf.rb
@@ -1,0 +1,15 @@
+base_dir = Pathname(__FILE__).dirname.parent.parent.parent.expand_path
+mkmf_gnome2_dir = base_dir + 'lib'
+
+$LOAD_PATH.unshift(mkmf_gnome2_dir.to_s)
+
+package_id = "gobject-2.0"
+require "mkmf-gnome"
+
+include_paths = PKGConfig.cflags_only_I(package_id)
+
+ext_dir = base_dir/"ext/glib2"
+
+$INCFLAGS << " #{include_paths} -I#{ext_dir}"
+
+create_makefile("callback_requester")

--- a/glib2/test/fixture/callback-requester/extconf.rb
+++ b/glib2/test/fixture/callback-requester/extconf.rb
@@ -1,3 +1,5 @@
+require "pathname"
+
 base_dir = Pathname(__FILE__).dirname.parent.parent.parent.expand_path
 mkmf_gnome2_dir = base_dir + 'lib'
 

--- a/glib2/test/test-callback.rb
+++ b/glib2/test/test-callback.rb
@@ -1,0 +1,9 @@
+require_relative "fixture/callback-requester/callback_requester"
+
+class TestCallback < Test::Unit::TestCase
+  def test_callback_segv
+    requester = CallbackRequester.new(Object.new)
+
+    assert_not_nil(requester)
+  end
+end


### PR DESCRIPTION
Hello,

This is a minimal reproducible patch for the segmentation fault in GLib2's callback feature I mentioned at https://github.com/ruby-gnome/ruby-gnome/pull/1731#issuecomment-5309756423.

I should see the SEGV by running:

    % cd glib2
    % ruby ./test/run-test.rb test-callback

This is not intended to be merged. Just for reporting.

I will keep researching the fix for this problem.

Thanks.
